### PR TITLE
BL-5083 Send custom device properties to Analytics

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/BloomReaderApplication.java
+++ b/app/src/main/java/org/sil/bloom/reader/BloomReaderApplication.java
@@ -3,11 +3,14 @@ package org.sil.bloom.reader;
 import android.app.Application;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import android.widget.Toast;
 
 import com.segment.analytics.Analytics;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.sil.bloom.reader.models.BookCollection;
 import org.sil.bloom.reader.models.ExtStorageUnavailableException;
 
@@ -20,6 +23,7 @@ import java.io.File;
 public class BloomReaderApplication extends Application {
     public static final String SHARED_PREFERENCES_TAG = "org.sil.bloom.reader.prefs";
     public static final String LAST_RUN_BUILD_CODE = "lastRunBuildCode";
+    public static final String DEVICE_ID_FILE = "deviceId.json";
 
     private String bookToHighlight;
     private static Context sApplicationContext;
@@ -57,9 +61,47 @@ public class BloomReaderApplication extends Application {
             e.printStackTrace();
         }
 
-
         // Set the initialized instance as a globally accessible instance.
         Analytics.setSingletonInstance(analytics);
+
+        // Check for deviceId json file and use its contents to identify this device
+        identifyDevice();
+    }
+
+    private static void identifyDevice(){
+        try {
+            String jsonString = getDeviceIdJson();
+            if (jsonString == null)
+                return;
+            JSONObject json = new JSONObject(jsonString);
+            String project = json.getString("project");
+            String device = json.getString("device");
+
+            // The value used with identify() needs to be globally unique. Just in case somebody
+            // might reuse a deviceId in a different project, we concatenate them.
+            String deviceId = project + "-" + device;
+            Analytics.with(getBloomApplicationContext()).identify(deviceId);
+            Analytics.with(getBloomApplicationContext()).group(project);
+        }
+        catch(JSONException e){
+            Log.e("Analytics", "Error processing deviceId file json.");
+            e.printStackTrace();
+        }
+    }
+
+    @Nullable
+    private static String getDeviceIdJson(){
+        try{
+            String filename = BookCollection.getLocalBooksDirectory().getPath() + File.separator + DEVICE_ID_FILE;
+            File deviceIdFile = new File(filename);
+            if(deviceIdFile.exists())
+                return IOUtilities.FileToString(deviceIdFile);
+            return null;
+        }
+        catch (ExtStorageUnavailableException e){
+            Log.e("Analytics", "Unable to check for deviceId file because external storage is unavailable.");
+            return null;
+        }
     }
 
     public static boolean InTestModeForAnalytics(){


### PR DESCRIPTION
Here's the simple version. The downside is that there's no feedback whatsoever. So if the guy in PNG fat-fingers the json file or puts it in the wrong place, he won't know about it. I would be happy to add a little toast with a success message the first time the json file is read or an appropriate error message, if that sounds good.

Also, is there a good place in the repo to put a sample deviceId.json? Would that be helpful?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/56)
<!-- Reviewable:end -->
