### PR TITLE
Success/Failure toasts for initial load of Device ID JSON.

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/BloomReaderApplication.java
+++ b/app/src/main/java/org/sil/bloom/reader/BloomReaderApplication.java
@@ -110,9 +110,10 @@ public class BloomReaderApplication extends Application {
         }
         catch (JSONException e){
             Log.e("Analytics", "Error processing deviceId file json.");
+            Log.e("Analytics", e.getMessage());
             e.printStackTrace();
 
-            Toast failToast = Toast.makeText(getBloomApplicationContext(), R.string.metadata_error, Toast.LENGTH_LONG);
+            Toast failToast = Toast.makeText(getBloomApplicationContext(), "Unable to load device metadata. JSON formatting error.", Toast.LENGTH_LONG);
             failToast.show();
 
             return false;
@@ -120,7 +121,7 @@ public class BloomReaderApplication extends Application {
     }
 
     private static void reportDeviceIdParseSuccess(String project, String device){
-        String successMessage = getBloomApplicationContext().getString(R.string.metadata_loaded) + "\nProject: " + project + "\nDevice: " + device;
+        String successMessage = "Device Metadata Loaded\nProject: " + project + "\nDevice: " + device;
         Toast success = Toast.makeText(getBloomApplicationContext(), successMessage, Toast.LENGTH_LONG);
         success.show();
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,4 +46,7 @@
     <string name="about_bloom">About Bloom</string>
     <string name="about_sil">About SIL</string>
     <string name="or">or</string>
+
+    <string name="metadata_loaded">Device Metadata Loaded</string>
+    <string name="metadata_error">Unable to load device metadata. JSON formatting error.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,7 +46,4 @@
     <string name="about_bloom">About Bloom</string>
     <string name="about_sil">About SIL</string>
     <string name="or">or</string>
-
-    <string name="metadata_loaded">Device Metadata Loaded</string>
-    <string name="metadata_error">Unable to load device metadata. JSON formatting error.</string>
 </resources>


### PR DESCRIPTION
During application onCreate, if there is no stored Device Id in the SharedPrefs, we check for a json file. If we succeed in parsing the file, there's a success toast. If we find a file but fail to parse it, there's a failure toast. Once device id metadata is loaded, we never look at the json again. This means changing the metadata requires a reinstall.

For the people loading the json file, once the file is transferred, they need to make sure BR is closed. Then they should run it and watch for the success message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/59)
<!-- Reviewable:end -->
