### PR TITLE
BL-5098 only one heading for shelf view

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/ShelfActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/ShelfActivity.java
@@ -1,12 +1,15 @@
 package org.sil.bloom.reader;
 
 import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.design.widget.NavigationView;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -19,7 +22,8 @@ import org.sil.bloom.reader.models.ExtStorageUnavailableException;
  * Created by Thomson on 10/20/2017.
  * Showing a bookshelf is much like our main activity, which also shows a list of books (and shelves--
  * something that just might come to this activity one day). For now we are using the same layout,
- * with the shelf label block hidden ('gone' so it doesn't even take up space) in the main activity.
+ * with the action bar changed to show the shelf icon, title and background and a back button instead
+ * of the menu.
  * There are just a few things we need to do differently.
  * It may at some point be worth refactoring to extract a common base class, but for now, I prefer
  * to see all the logic in the class that primarily uses it and for which it was originally written,
@@ -39,21 +43,51 @@ public class ShelfActivity extends MainActivity {
 
         filter = getIntent().getStringExtra("filter");
 
-        // Turn on the bookshelf label (hidden in MainActivity) and initialize it with the data
+        // Initialize the bookshelf label (empty in MainActivity) with the data
         // passed through our intent.
-        LinearLayout label = (LinearLayout) findViewById(R.id.shelf_label_layout);
-        label.setVisibility(View.VISIBLE);
-        label.setBackgroundColor(Color.parseColor("#" + getIntent().getStringExtra("background")));
+        View toolbar = findViewById(R.id.toolbar);
+        final int background = Color.parseColor("#" + getIntent().getStringExtra("background"));
+        toolbar.setBackgroundColor(background);
         TextView labelText = (TextView) findViewById(R.id.shelfName);
         labelText.setText(getIntent().getStringExtra("label"));
+        ImageView bloomIcon = (ImageView)findViewById(R.id.bloom_icon);
+        // replace the main bloom icon with the bookshelf one.
+        bloomIcon.setImageResource(R.drawable.bookshelf);
 
-        Button backButton = (Button) findViewById(R.id.back_button);
-        backButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                finish();
-            }
-        });
+        // The color chosen for the bookshelf may not contrast well with the default white
+        // color of text and the back arrow and the default black color of the bookshelf icon.
+        // Change them all to black or white, whichever gives better contrast.
+        int forecolor = pickTextColorBasedOnBgColor(background, Color.WHITE, Color.BLACK);
+        labelText.setTextColor(forecolor);
+        // This bit of magic from https://stackoverflow.com/questions/26788464/how-to-change-color-of-the-back-arrow-in-the-new-material-theme
+        // makes the the back arrow use the contrasting foreground color
+        Drawable upArrow = ((android.support.v7.widget.Toolbar)toolbar).getNavigationIcon();
+        upArrow.setColorFilter(forecolor, PorterDuff.Mode.SRC_ATOP);
+
+        // And this bit, from https://stackoverflow.com/questions/1309629/how-to-change-colors-of-a-drawable-in-android,
+        // switches the color of the bookshelf icon.
+        bloomIcon.setColorFilter(forecolor);
+    }
+
+    // official W3C recommendation for deciding whether a light or dark color will contrast best
+    // with the given background color. The right one to use is returned.
+    // Based on https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
+    int pickTextColorBasedOnBgColor(int bgColor, int lightColor, int darkColor) {
+        int r = (bgColor >> 16) & 0xff;
+        int g = (bgColor >> 8) & 0xff;
+        int b = bgColor & 0xff;
+        double[] uicolors = new double[] {r / 255, g / 255, b / 255};
+        double[] c = new double[3];
+        for (int i = 0; i < 3; i++) {
+            double col = uicolors[i];
+            if (col < 0.03928)
+                c[i] = col/12.92;
+            else
+                c[i] = Math.pow((col + 0.055)/1.055, 2.4);
+        }
+
+        double luminance = (0.2126 * c[0]) + (0.7152 * c[1]) + (0.0722 * c[2]);
+        return (luminance > 0.179) ? darkColor : lightColor;
     }
 
     // In the shelf view the action bar's menu is replaced with a back button.

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context="org.sil.bloom.reader.MainActivity">
+    tools:context="org.sil.bloom.activities.MainActivity">
 
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"
@@ -19,53 +19,23 @@
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/AppTheme.PopupOverlay">
             <ImageView
+                android:id="@+id/bloom_icon"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 app:srcCompat="@drawable/bloom_against_dark"/>
-        </android.support.v7.widget.Toolbar>
-
-    </android.support.design.widget.AppBarLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:layout_marginTop="?attr/actionBarSize" >
-        <!-- This component is made visible in the shelf activity-->
-        <LinearLayout
-            android:id="@+id/shelf_label_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:paddingLeft="@dimen/activity_horizontal_margin"
-            android:paddingTop="6dp"
-            android:paddingBottom="6dp"
-            android:visibility="gone" >
-
-            <Button
-                android:id="@+id/back_button"
-                android:layout_width="30dp"
-                android:layout_height="30dp"
-                android:layout_marginEnd="30dp"
-                android:background="@drawable/ic_arrow_back_black_48dp" />
-            <ImageView
-                android:id="@+id/shelfImage"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingEnd="10dp"
-                app:srcCompat="@drawable/bookshelf" />
-
             <TextView
                 android:id="@+id/shelfName"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:layout_marginLeft="5dp"
                 android:ems="10"
-                android:text="Name"
+                android:text=""
                 android:textAppearance="?attr/textAppearanceSearchResultTitle"/>
-        </LinearLayout>
+        </android.support.v7.widget.Toolbar>
+
+    </android.support.design.widget.AppBarLayout>
 
         <include layout="@layout/content_main" />
-    </LinearLayout>
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Since its parent is a linear layout and it is the only thing with layout-weight,
-its height will actually be enough to fill the parent.-->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/content_main"
     android:layout_width="match_parent"
-    android:layout_height="100dp"
+    android:layout_height="match_parent"
     android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    android:layout_weight="1"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:context="org.sil.bloom.reader.MainActivity"
+    tools:context="org.sil.bloom.activities.MainActivity"
     tools:showIn="@layout/app_bar_main">
 
     <FrameLayout


### PR DESCRIPTION
This backs out part of the previous change that added a shelf label, and updates the main toolbar to look like it. Along the way I realized that we need to ensure a contrasting foreground color in the heading, and did that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/63)
<!-- Reviewable:end -->
