### PR TITLE
[BL-5100] Add a broadcast receiver for connectivity changes, so that …

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -187,6 +187,14 @@
             android:name=".ShelfActivity"
             android:label="@string/title_activity_shelf"
             android:theme="@style/AppTheme.NoActionBar"></activity>
+
+        <receiver android:name="org.sil.bloom.reader.ConnectivityReceiver"
+            android:enabled="true">
+            <intent-filter>
+                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
+            </intent-filter>
+        </receiver>
+
         <provider
             android:authorities="${applicationId}.fileprovider"
             android:name="android.support.v4.content.FileProvider"

--- a/app/src/main/java/org/sil/bloom/reader/ConnectivityReceiver.java
+++ b/app/src/main/java/org/sil/bloom/reader/ConnectivityReceiver.java
@@ -1,0 +1,19 @@
+package org.sil.bloom.reader;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+/**
+ * Created by rick on 11/2/17.
+ */
+
+public class ConnectivityReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        // Funny story: we don't actually have to do anything here.
+        // Receiving this broadcast also calls Application.onCreate
+        // if the app wasn't running in the bg already
+    }
+}


### PR DESCRIPTION
…analytics will be sent when internet becomes available even if the app is not running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/65)
<!-- Reviewable:end -->
