### PR TITLE
BL-5199 Re-enable Proguard (with many problems suppressed)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ android {
     buildTypes {
         release {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            minifyEnabled false
+            minifyEnabled true
             signingConfig signingConfigs.release
         }
         debug {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,34 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# generate a file that can be useful in debugging conflicts
+#-printconfiguration 'proguardConfiguration.txt'
+
+# duplicate classes in these domains are pulled in from
+# -libraryjars 'D:\tools\android\platforms\android-23\android.jar' and
+# -libraryjars 'D:\tools\android\platforms\android-23\optional\org.apache.http.legacy.jar'
+# according to https://stackoverflow.com/questions/33047806/proguard-duplicate-definition-of-library-class
+# there's nothing to be done about it except ignore it.
+-dontnote android.net.http.*
+-dontnote org.apache.http.conn.*
+-dontnote org.apache.http.conn.scheme.*
+-dontnote org.apache.http.params.HttpParams
+
+# We get a whole mess of warnings (over 200!) about classes not found. Apparently they are things
+# needed for some parts of org.apache.commons.compress but not the tiny part we are using, since
+# our code actually works without them. Proguard crashes when these warnings aren't suppressed,
+# so I went ahead and suppressed them all.
+-dontwarn org.apache.commons.compress.archivers.Lister
+-dontwarn org.apache.commons.compress.archivers.sevenz.*
+-dontwarn org.apache.commons.compress.archivers.zip.*
+-dontwarn org.apache.commons.compress.compressors.brotli.BrotliCompressorInputStream
+-dontwarn org.apache.commons.compress.compressors.lzma.LZMACompressorInputStream
+-dontwarn org.apache.commons.compress.compressors.pack200.TempFileCachingStreamBridge
+-dontwarn org.apache.commons.compress.compressors.xz.*
+-dontwarn org.apache.commons.compress.parallel.*
+-dontwarn org.apache.commons.compress.utils.*
+-dontwarn org.apache.commons.compress.compressors.lzma.LZMACompressorOutputStream
+
+# We're not hiding anything...we're open source!
+-dontobfuscate


### PR DESCRIPTION
A bunch of notes and warnings seem inseparable from using org.apache.commons:commons-compress:1.14. If we don't suppress them proguard crashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/68)
<!-- Reviewable:end -->
