### PR TITLE
[BL-5505] Recover from corrupted FileDescriptor during .bloombundle import

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/IOUtilities.java
+++ b/app/src/main/java/org/sil/bloom/reader/IOUtilities.java
@@ -3,6 +3,7 @@ package org.sil.bloom.reader;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.net.Uri;
+import android.util.Log;
 import android.widget.Toast;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -313,19 +314,26 @@ public class IOUtilities {
     public static List<String> untar(FileInputStream input, String targetPath) throws IOException {
         TarArchiveInputStream tarInput = new TarArchiveInputStream(input);
         ArrayList<String> result = new ArrayList<String>();
-
         ArchiveEntry  entry;
         while ((entry = tarInput.getNextEntry()) != null) {
             File destPath=new File(targetPath,entry.getName());
             result.add(destPath.getPath());
             if (!entry.isDirectory()) {
                 FileOutputStream fout=new FileOutputStream(destPath);
-                final byte[] buffer=new byte[8192];
-                int n=0;
-                while (-1 != (n=tarInput.read(buffer))) {
-                    fout.write(buffer,0,n);
+                try{
+                    final byte[] buffer=new byte[8192];
+                    int n=0;
+                    while (-1 != (n=tarInput.read(buffer))) {
+                        fout.write(buffer,0,n);
+                    }
+                    fout.close();
                 }
-                fout.close();
+                catch (IOException e) {
+                    fout.close();
+                    destPath.delete();
+                    tarInput.close();
+                    throw e;
+                }
             }
             else {
                 destPath.mkdir();
@@ -338,7 +346,24 @@ public class IOUtilities {
     // Returns a list of paths to the books created.
     public static List<String> extractBloomBundle(Context context, Uri bloomBundleUri) throws IOException {
         FileDescriptor fd = context.getContentResolver().openFileDescriptor(bloomBundleUri, "r").getFileDescriptor();
-        //Review: do we want to just put them all in the Bloom directory directly like this?
-        return untar(new FileInputStream(fd), getLocalBooksDirectory().getAbsolutePath());
+        if(fd.valid()) {
+            try {
+                //Review: do we want to just put them all in the Bloom directory directly like this?
+                return untar(new FileInputStream(fd), getLocalBooksDirectory().getAbsolutePath());
+            } catch (IOException e) {
+                Log.e("BundleIO", e.getMessage());
+                // Maybe 10-20% of the time (with a medium sized bundle),
+                // a valid FileDescriptor becomes invalid during the unpacking process
+                // Having not found a way to prevent this, we catch it and try again
+                // If the IOException is something else, it should go through
+                if (!fd.valid())
+                    return extractBloomBundle(context, bloomBundleUri);
+                else
+                    throw e;
+            }
+        }
+        else {
+            throw new IOException("Invalid FileDescriptor from bloombundle");
+        }
     }
 }

--- a/app/src/main/java/org/sil/bloom/reader/MainActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/MainActivity.java
@@ -167,7 +167,8 @@ public class MainActivity extends BaseActivity
             }
         }
         catch (IOException e) {
-            Log.e("BloomReader", "IO exception reading bloom bundle: " + e.getMessage());
+            Log.e("BundleIO", "IO exception reading bloom bundle: " + e.getMessage());
+            e.printStackTrace();
             Toast.makeText(this, "Had a problem reading the bundle", Toast.LENGTH_LONG).show();
         }
         try {


### PR DESCRIPTION
If a valid FileDescriptor becomes invalid during the extraction, it now restarts the extraction.

For an actual corrupt file (I made one and tested this), the FileDescriptor does not become invalid, and the IOException gets passed up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/91)
<!-- Reviewable:end -->
