### PR TITLE
BL-5555 Fix for cached images

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/ReaderActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/ReaderActivity.java
@@ -24,6 +24,11 @@ import android.widget.TextView;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Properties;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.sil.bloom.reader.models.BookOrShelf;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,11 +37,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.sil.bloom.reader.models.BookOrShelf;
 
 
 public class ReaderActivity extends BaseActivity {
@@ -121,6 +121,17 @@ public class ReaderActivity extends BaseActivity {
         }
         super.onPause();
         WebAppInterface.stopAllAudio();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if(mCurrentView != null) {
+            // BL-5555
+            mCurrentView.clearCache(false); // Clear images from memory when the backbutton is pressed
+            // After clearing the cache bloomPlayer.js is missing and so loading the next book does not play the initial audio. Reloading the WebView fixes that issue.
+            mCurrentView.reload();
+        }
+        super.onBackPressed();
     }
 
     private void ReportPagesRead()


### PR DESCRIPTION
Please review the fix below for the issue BL-5555. I am a little concerned that the reload of the web view may cause other issues, but I could not see any. I did this because after clearing the cache it also cleared out bloomPlayer.js. Unfortunately like a web browser there is no way to clear just images.

Note, sorry for the reordering of the imports. I think I still have Android Studio set to automatically clean those. I can fix that if need be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/95)
<!-- Reviewable:end -->
