### PR TITLE
[BL-5504] Hide the status bar in the Reader Activity.

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/ReaderActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/ReaderActivity.java
@@ -126,6 +126,12 @@ public class ReaderActivity extends BaseActivity {
         WebAppInterface.stopAllAudio();
     }
 
+    @Override
+    protected void onResume(){
+        super.onResume();
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN + View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+    }
+
     private void ReportPagesRead()
     {
         try {

--- a/app/src/main/res/layout/activity_reader.xml
+++ b/app/src/main/res/layout/activity_reader.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    tools:context="org.sil.bloom.ReaderActivity">
+    tools:context="org.sil.bloom.reader.ReaderActivity">
 
     <RelativeLayout
         android:id="@+id/loadingPanel"

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -4,7 +4,6 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="windowActionModeOverlay">true</item>
     </style>
 </resources>


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-5504

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/103)
<!-- Reviewable:end -->
