### PR TITLE
[BL-5730] Make all shared bloom bundles use the file name that is kno…

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/SharingManager.java
+++ b/app/src/main/java/org/sil/bloom/reader/SharingManager.java
@@ -89,7 +89,7 @@ public class SharingManager {
         for (int i=0; i<booksAndShelves.size(); ++i)
             files[i] = new File(booksAndShelves.get(i).path);
         try {
-            String path = sharedBloomBundlePath(shelf.name);
+            String path = sharedBloomBundlePath();
             IOUtilities.tar(files, path);
             shareFile(Uri.fromFile(new File(path)), "application/zip", mContext.getString(R.string.share_books_via));
         }
@@ -163,9 +163,5 @@ public class SharingManager {
         deviceName = (deviceName != null && !deviceName.isEmpty()) ? deviceName : "my";
 
         return sharedFilePath(deviceName + IOUtilities.BLOOM_BUNDLE_FILE_EXTENSION);
-    }
-
-    private static String sharedBloomBundlePath(String shelfName) {
-        return sharedFilePath(shelfName + IOUtilities.BLOOM_BUNDLE_FILE_EXTENSION);
     }
 }


### PR DESCRIPTION
Make all shared bloom bundles use the file name that is known to our periodic cleanup function.

https://silbloom.myjetbrains.com/youtrack/issue/BL-5730

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/110)
<!-- Reviewable:end -->
