### PR TITLE
[BL-5764] Turn on sensor rotation for canrotate books even if the use…

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/ReaderActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/ReaderActivity.java
@@ -606,7 +606,7 @@ public class ReaderActivity extends BaseActivity {
                 mOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE; // fixed landscape
         }
         if (getFeatureValue("canrotate", "never").equals("allOrientations"))
-            mOrientation = ActivityInfo.SCREEN_ORIENTATION_USER; // change as rotated
+            mOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR; // change as rotated
 
         setRequestedOrientation(mOrientation);
         return mOrientation;


### PR DESCRIPTION
Turn on sensor rotation for canrotate books even if the user has disabled sensor rotation in the device settings.

https://silbloom.myjetbrains.com/youtrack/issue/BL-5764

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/115)
<!-- Reviewable:end -->
