### PR TITLE
[BL-6445] Bump target API to 26

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ if (rootProject.file(fileName).exists()) {
 }
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 26
     buildToolsVersion '27.0.3'
 
     playAccountConfigs {
@@ -29,7 +29,7 @@ android {
     defaultConfig {
         applicationId "org.sil.bloom.reader"
         minSdkVersion 19
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode versionMajor * 100000 + versionMinor * 1000 + versionRelease.toInteger()
         versionName "${versionMajor}.${versionMinor}.${versionRelease}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Google is requiring all updates to apps to target API 26 (Android 8.0) or higher starting in November.

https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html

Issue: https://issues.bloomlibrary.org/youtrack/issue/BL-6445

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/132)
<!-- Reviewable:end -->