### PR TITLE
[BL-6445] Set Target API to 26 and make necessary updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ if (rootProject.file(fileName).exists()) {
 }
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 26
     buildToolsVersion '27.0.3'
 
     playAccountConfigs {
@@ -29,7 +29,7 @@ android {
     defaultConfig {
         applicationId "org.sil.bloom.reader"
         minSdkVersion 19
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode versionMajor * 100000 + versionMinor * 1000 + versionRelease.toInteger()
         versionName "${versionMajor}.${versionMinor}.${versionRelease}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -111,10 +111,10 @@ dependencies {
     androidTestImplementation ('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'com.android.support:appcompat-v7:23.4.0'
-    implementation  'com.android.support:support-v4:23.4.0'
-    implementation  'com.android.support:recyclerview-v7:23.4.0'
-    implementation  'com.android.support:design:23.4.0'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation  'com.android.support:support-v4:26.1.0'
+    implementation  'com.android.support:recyclerview-v7:26.1.0'
+    implementation  'com.android.support:design:26.1.0'
     // Supports the WiFi module's 'server' used to receive books from Bloom desktop
     implementation  'cz.msebera.android:httpclient:4.4.1.2'
     implementation  'com.segment.analytics.android:analytics:4.+'
@@ -123,9 +123,9 @@ dependencies {
     //implementation  'commons-io:commons-compress:1.15'
     // Needed (at least) for making tar archives to send multiple books.
     implementation  'org.apache.commons:commons-compress:1.14'
+    implementation  'com.android.support.constraint:constraint-layout:1.1.3'
 
     testImplementation  'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.+'
-    testImplementation 'org.json:json:20180813'  // make org.json classes available in unit tests
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    testImplementation  'org.mockito:mockito-core:2.22.0'
+    testImplementation  'org.json:json:20180813'  // make org.json classes available in unit tests
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -208,7 +208,7 @@
         </receiver>
 
         <provider
-            android:authorities="${applicationId}.fileprovider"
+            android:authorities="org.sil.bloom.reader.fileprovider"
             android:name="android.support.v4.content.FileProvider"
             android:grantUriPermissions="true"
             android:exported="false">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,10 +3,10 @@
     package="org.sil.bloom.reader"
     android:installLocation="auto">
 
+    <!-- Normal Permissions - granted by being in Manifest -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <!-- So that just for the duration of WiFi transfer we can hold a lock. -->
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <!-- Used at least for analytics, soon for Bloom Library download. Was present when I added
     analytics, so may be used for something else also. -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -17,6 +17,10 @@
     <!-- currently just because it's how we get the device name for WiFi, but eventually we will have
     other Bluetooth functions. -->
     <uses-permission android:name="android.permission.BLUETOOTH"/>
+
+    <!-- Dangerous Permissions - must be requested at runtime -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".BloomReaderApplication"

--- a/app/src/main/java/org/sil/bloom/reader/BaseActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/BaseActivity.java
@@ -27,7 +27,8 @@ public abstract class BaseActivity extends AppCompatActivity {
 
     // Call in onPause if subclass calls startObserving in OnResume.
     protected void stopObserving() {
-        mHandler.removeCallbacks(mObserver);
+        if (mHandler != null)
+            mHandler.removeCallbacks(mObserver);
     }
 
     // We want to monitor for new and changed books. We ought to be able to get notifications

--- a/app/src/main/java/org/sil/bloom/reader/BloomReaderApplication.java
+++ b/app/src/main/java/org/sil/bloom/reader/BloomReaderApplication.java
@@ -34,11 +34,26 @@ public class BloomReaderApplication extends Application {
     // Created by main activity, used also by shelf activities. The active one controls its filter.
     public static BookCollection theOneBookCollection;
 
+    public static boolean stillNeedToSetupAnalytics = false;
+
     @Override
     public void onCreate() {
         super.onCreate();
         sApplicationContext = getApplicationContext();
+        if (MainActivity.haveStoragePermission(this))
+            setupAnalytics(this);
+        else
+            stillNeedToSetupAnalytics = true;
+    }
 
+    public static void setupAnalyticsIfNeeded(Context context) {
+        if (stillNeedToSetupAnalytics) {
+            stillNeedToSetupAnalytics = false;
+            setupAnalytics(context);
+        }
+    }
+
+    private static void setupAnalytics(Context context) {
         String writeKey = "FSepBapJtfOi3FfhsEWQjc2Dw0O3ixuY"; // Source BloomReaderTest
 
         if (InTestModeForAnalytics()) {
@@ -60,7 +75,7 @@ public class BloomReaderApplication extends Application {
                 .build();
 
         try {
-            String version = getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
+            String version = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionName;
             String[] numbers = version.split("\\.");
             analytics.getAnalyticsContext().putValue("majorMinor", numbers[0] + "." + numbers[1]);
         } catch (PackageManager.NameNotFoundException e) {
@@ -135,10 +150,11 @@ public class BloomReaderApplication extends Application {
         if(testMode)
             return true;
         try{
+            File bookDirectory = BookCollection.getLocalBooksDirectory();
             // We'd really like to just ignore case, but no easy way to do it.
-            return new File(BookCollection.getLocalBooksDirectory(), "UseTestAnalytics").exists()
-                    || new File(BookCollection.getLocalBooksDirectory(), "useTestAnalytics").exists()
-                    || new File(BookCollection.getLocalBooksDirectory(), "usetestanalytics").exists();
+            return new File(bookDirectory, "UseTestAnalytics").exists()
+                    || new File(bookDirectory, "useTestAnalytics").exists()
+                    || new File(bookDirectory, "usetestanalytics").exists();
         }
         catch (ExtStorageUnavailableException e){
             Log.e("BloomReader/FileIO", e.getStackTrace().toString());

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -12,30 +12,13 @@
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar
-            android:id="@+id/toolbar"
+        <include
+            layout="@layout/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay">
-            <ImageView
-                android:id="@+id/bloom_icon"
-                android:layout_height="wrap_content"
-                android:layout_width="wrap_content"
-                app:srcCompat="@drawable/bloom_against_dark"/>
-            <TextView
-                android:id="@+id/shelfName"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_marginLeft="5dp"
-                android:ems="10"
-                android:text=""
-                android:textAppearance="?attr/textAppearanceSearchResultTitle"/>
-        </android.support.v7.widget.Toolbar>
+            android:layout_height="wrap_content" />
 
     </android.support.design.widget.AppBarLayout>
 
-        <include layout="@layout/content_main" />
+    <include layout="@layout/content_main" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/blank.xml
+++ b/app/src/main/res/layout/blank.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        layout="@layout/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/need_storage_permission.xml
+++ b/app/src/main/res/layout/need_storage_permission.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        layout="@layout/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="24dp"
+        android:layout_weight="1"
+        android:textSize="20sp"
+        android:text="@string/need_storage_permission"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:layout_margin="24dp"
+        android:padding="12dp"
+        android:background="@color/colorBloomRed"
+        android:textColor="#FFFFFF"
+        android:text="@string/grant_storage_permission"
+        android:onClick="requestStoragePermission"/>
+</LinearLayout>

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:background="?attr/colorPrimary"
+    app:popupTheme="@style/AppTheme.PopupOverlay">
+
+    <ImageView
+        android:id="@+id/bloom_icon"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        app:srcCompat="@drawable/bloom_against_dark"/>
+    <TextView
+        android:id="@+id/shelfName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginLeft="5dp"
+        android:ems="10"
+        android:text=""
+        android:textAppearance="?attr/textAppearanceSearchResultTitle"/>
+</android.support.v7.widget.Toolbar>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,7 @@
     <string name="receive_books_over_wifi">Receive books from computer</string>
 
     <string name="bloomReaderUrl" translatable="false"><u>bloomlibrary.org</u></string>
+
+    <string name="need_storage_permission">Bloom Reader needs access to file storage in order to work.</string>
+    <string name="grant_storage_permission">Grant Storage Permission</string>
 </resources>

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-path name="Bloom" path="Bloom" />
+    <external-path name="Bloom" path="/" />
 </paths>


### PR DESCRIPTION
- Bump target API to 26
- Request storage permissions at runtime
- Use a FileProvider for sharing files with a content URI rather than a regular File URI.

Issue: https://issues.bloomlibrary.org/youtrack/issue/BL-6445

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/134)
<!-- Reviewable:end -->
