### PR TITLE
[BL-6474] Use Application Id for FileProvider authority vice hardcode…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -208,7 +208,7 @@
         </receiver>
 
         <provider
-            android:authorities="org.sil.bloom.reader.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:name="android.support.v4.content.FileProvider"
             android:grantUriPermissions="true"
             android:exported="false">

--- a/app/src/main/java/org/sil/bloom/reader/SharingManager.java
+++ b/app/src/main/java/org/sil/bloom/reader/SharingManager.java
@@ -119,7 +119,7 @@ public class SharingManager {
     }
 
     private void shareFile(File file, String fileType, String dialogTitle){
-        Uri uri = FileProvider.getUriForFile(mActivity, "org.sil.bloom.reader.fileprovider", file);
+        Uri uri = FileProvider.getUriForFile(mActivity, BuildConfig.APPLICATION_ID + ".fileprovider", file);
         Intent shareIntent = ShareCompat.IntentBuilder.from(mActivity)
                 .setStream(uri)
                 .getIntent()


### PR DESCRIPTION
…d org.sil.bloom.reader so that multiple versions of BR can continue live together on the same device in harmony.

Issue: https://issues.bloomlibrary.org/youtrack/issue/BL-6474

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/135)
<!-- Reviewable:end -->
