### PR TITLE
[BL-6521] Fix button color in the Delete Book/Shelf Dialog.

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/MainActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/MainActivity.java
@@ -391,7 +391,7 @@ public class MainActivity extends BaseActivity
     }
 
     private void deleteBook(final BookOrShelf book) {
-        new AlertDialog.Builder(this).setMessage(getString(R.string.deleteExplanationBook, book.name))
+        new AlertDialog.Builder(this, R.style.SimpleDialogTheme).setMessage(getString(R.string.deleteExplanationBook, book.name))
                 .setTitle(getString(R.string.deleteConfirmation))
                 .setPositiveButton(getString(R.string.deleteConfirmButton), new DialogInterface.OnClickListener() {
                     @Override

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,11 +41,11 @@
     </style>
 
     <style name="SimpleDialogTheme" parent="Theme.AppCompat.Light.Dialog">
-        <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
+        <item name="buttonBarButtonStyle">@style/DialogButtonStyle</item>
         <item name="android:textColorLink">@color/colorBloomRed</item>
     </style>
 
-    <style name="PositiveButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+    <style name="DialogButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
         <item name="android:textColor">@color/colorBloomRed</item>
     </style>
 


### PR DESCRIPTION
This makes the button color Bloom Red like in the other dialogs we have.

Issue: https://issues.bloomlibrary.org/youtrack/issue/BL-6521

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/136)
<!-- Reviewable:end -->
