### PR TITLE
Better method for cleaning up files after importing books & bundles

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/BookFinderTask.java
+++ b/app/src/main/java/org/sil/bloom/reader/BookFinderTask.java
@@ -23,23 +23,9 @@ public class BookFinderTask extends AsyncTask<Void, Void, Void> {
 
     @Override
     public Void doInBackground(Void... v) {
-        // Scan public on-device storage
-        String externalStoragePath = Environment.getExternalStorageDirectory().getPath();
-        scan(new File(externalStoragePath));
+        scan(IOUtilities.removablePublicStorageRoot(activity));
+        scan(IOUtilities.nonRemovablePublicStorageRoot(activity));
 
-        // Hackishly find sdcard and scan that too
-        File[] publicBloomReaderDirs = activity.getExternalFilesDirs(null);
-        for (File dir : publicBloomReaderDirs) {
-            // Google Play Console proves dir can be null somehow
-            if (dir != null && dir.getPath().contains("Android")) {
-                while (!dir.getName().equals("Android"))
-                    dir = dir.getParentFile();
-                dir = dir.getParentFile(); // The parent directory of Android/
-                if (!dir.getPath().equals(externalStoragePath)) {
-                    scan(dir);
-                }
-            }
-        }
         return null;
     }
 

--- a/app/src/main/java/org/sil/bloom/reader/FileCleanupTask.java
+++ b/app/src/main/java/org/sil/bloom/reader/FileCleanupTask.java
@@ -1,0 +1,139 @@
+package org.sil.bloom.reader;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Build;
+import android.os.Environment;
+import android.util.Log;
+
+import org.sil.bloom.reader.models.BookCollection;
+import org.sil.bloom.reader.models.ExtStorageUnavailableException;
+
+import java.io.File;
+
+/*
+    Used to clean up a bloombundle or bloomd file after importing the contents into
+    the Bloom directory.
+
+    We only want to do this if the file is in non-removable storage.
+    If the file is on an sd card, we leave it alone so that the sd card
+    can be passed to another device to import the same file.
+ */
+
+public class FileCleanupTask extends AsyncTask<Void, Void, Void> {
+    private Context context;
+    private Uri searchFileUri;
+    private File bloomDirectory; // We don't want to search here
+
+    public FileCleanupTask(Context context, Uri searchFileUri) {
+        this.context = context;
+        this.searchFileUri = searchFileUri;
+    }
+
+    @Override
+    public Void doInBackground(Void... v) {
+        // If the URI is file:// we have direct access to the file,
+        // otherwise we have to search for it
+
+        if (searchFileUri.getScheme() == "file") {
+            File searchFile = new File(searchFileUri.getPath());
+            if (onNonRemovableStorage(searchFile))
+                searchFile.delete();
+            return null;
+        }
+
+        try {
+            bloomDirectory = BookCollection.getLocalBooksDirectory();
+
+            File nonRemovableStorageDir = getNonRemovableStorageDir();
+            if (nonRemovableStorageDir == null)
+                return null;
+
+            File fileToDelete = searchForFile(nonRemovableStorageDir);
+
+            if (fileToDelete != null)
+                fileToDelete.delete();
+        }
+        catch (ExtStorageUnavailableException e) {
+            Log.e("BloomReader", e.getLocalizedMessage());
+        }
+
+        return null;
+    }
+
+    private boolean onNonRemovableStorage(File file) {
+        if (Build.VERSION.SDK_INT >= 21)
+            return !Environment.isExternalStorageRemovable(file);
+
+        // True if default storage is non-removable and the file is in that directory
+        return (!Environment.isExternalStorageRemovable() &&
+                file.getPath().startsWith(Environment.getExternalStorageDirectory().getPath()));
+    }
+
+    private File getNonRemovableStorageDir() {
+        // Common case - primary "external" storage is non-removable
+        if (!Environment.isExternalStorageRemovable())
+            return Environment.getExternalStorageDirectory();
+
+        return findNonRemovableStorageDir();
+    }
+
+    private File findNonRemovableStorageDir() {
+        if (Build.VERSION.SDK_INT >= 21) {
+            File[] appStorageDirs = context.getExternalFilesDirs("");
+            for (File appStorageDir : appStorageDirs) {
+                if (!Environment.isExternalStorageRemovable(appStorageDir))
+                    return getNonRemovableStorageRootDir(appStorageDir);
+            }
+        }
+        return null;
+    }
+
+    private File getNonRemovableStorageRootDir(File appStorageDir) {
+        // appStorageDir is a directory within the public storage with a path like
+        // /path/to/public/storage/Android/data/org.sil.bloom.reader/files
+
+        String path = appStorageDir.getPath();
+        int androidDirIndex = path.indexOf(File.separator + "Android" + File.separator);
+        if (androidDirIndex > 0)
+            return new File(path.substring(0, androidDirIndex));
+        return null;
+    }
+
+    private File searchForFile(File dir) {
+        if (dir == null)
+            return null;
+
+        File[] list = dir.listFiles();
+        if (list == null)
+            return null;
+
+        for (File f : list) {
+            if (f.isFile() && matchesSearchFile(f))
+                return f;
+            if (f.isDirectory() && !f.equals(bloomDirectory)) {
+                File fileToDelete = searchForFile(f);
+                if (fileToDelete != null)
+                    return fileToDelete;
+            }
+        }
+        return null;
+    }
+
+    private boolean matchesSearchFile(File file) {
+        return file.getName().equals(searchFileName());
+    }
+
+    private String searchFileName() {
+        // path is probably something like /document/primary:MyBook.bloomd
+        String path = searchFileUri.getPath();
+        int separatorIndex = Math.max(
+                                path.lastIndexOf(File.separator),
+                                path.lastIndexOf(':')
+        );
+        if (separatorIndex < 0)
+            return path;
+        return path.substring(separatorIndex + 1);
+    }
+}

--- a/app/src/main/java/org/sil/bloom/reader/FileSearchState.java
+++ b/app/src/main/java/org/sil/bloom/reader/FileSearchState.java
@@ -1,0 +1,30 @@
+package org.sil.bloom.reader;
+
+import android.net.Uri;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+    Used in MainActivity to track the state of an ongoing File Search
+ */
+
+public class FileSearchState {
+    // These have been imported, but original files haven't been cleaned up yet
+    public List<Uri> bloomdsAdded = new ArrayList<>();
+
+    // These will all be imported at the end (and cleaned up at the same time)
+    public List<Uri> bundlesToAdd = new ArrayList<>();
+
+    public boolean nothingAdded() {
+        return bloomdsAdded.isEmpty() && bundlesToAdd.isEmpty();
+    }
+
+    public Uri[] bloomdsAddedAsArray() {
+        return bloomdsAdded.toArray(new Uri[0]);
+    }
+
+    public Uri[] bundlesToAddAsArray() {
+        return bundlesToAdd.toArray(new Uri[0]);
+    }
+}

--- a/app/src/main/java/org/sil/bloom/reader/IOUtilities.java
+++ b/app/src/main/java/org/sil/bloom/reader/IOUtilities.java
@@ -207,31 +207,6 @@ public class IOUtilities {
         }
     }
 
-    // In case of doubt we return false
-    public static boolean isInNonRemovableStorage(Context context, File file) {
-        try {
-            if (Build.VERSION.SDK_INT >= 21)
-                return !Environment.isExternalStorageRemovable(file);
-
-            if (Environment.isExternalStorageRemovable())
-                return false; // Primary ext storage is removable. No confidence we can determine our file isn't on that
-
-            // Since we're here, the primary external storage is nonremovable. Is our file in that directory?
-            String extStoragePath = context.getExternalFilesDir("").getAbsolutePath();
-            // Expect the path to be something like /path/to/nonremovable/ext/storage/Android/data/org.sil.bloom.reader/files/
-            // Chopping off /Android/... gives us a path to nonremovable external storage
-            int index = extStoragePath.indexOf(File.separator + "Android" + File.separator);
-            if (index < 0)
-                return false;  // Didn't get the path we expected
-            extStoragePath = extStoragePath.substring(0, index);
-            return file.getAbsolutePath().startsWith(extStoragePath);
-        } catch (IllegalArgumentException e) {
-            // This happens when trying to evaluate Environment.isExternalStorageRemovable() on
-            // files from a content:// URI
-            return false;
-        }
-    }
-
     public static String FileToString(File file) {
         try {
             return InputStreamToString(new FileInputStream(file));

--- a/app/src/main/java/org/sil/bloom/reader/ImportBundleTask.java
+++ b/app/src/main/java/org/sil/bloom/reader/ImportBundleTask.java
@@ -24,17 +24,22 @@ public class ImportBundleTask extends AsyncTask<Uri, String, Void> {
     private IOException ioException;
     private Toast toast;
     private List<String> newBookPaths;
+    private List<Uri> bundlesToCleanUp;
 
     ImportBundleTask(MainActivity mainActivity) {
         this.mainActivity = mainActivity;
+        // Using a single toast object allows us to update the message immediately
         this.toast = Toast.makeText(mainActivity, "", Toast.LENGTH_SHORT);
-        this.newBookPaths = new ArrayList<String>();
+        this.newBookPaths = new ArrayList<>();
+        this.bundlesToCleanUp = new ArrayList<>();
     }
 
     protected Void doInBackground(Uri... bundleUris) {
         try {
-            bloomBundleUri = bundleUris[0];
-            extractBloomBundle(bloomBundleUri);
+            for(Uri bloomBundleUri : bundleUris) {
+                extractBloomBundle(bloomBundleUri);
+                bundlesToCleanUp.add(bloomBundleUri);
+            }
         }
         catch (IOException e) {
             ioException = e;
@@ -61,9 +66,8 @@ public class ImportBundleTask extends AsyncTask<Uri, String, Void> {
             toast.setText(toastMessage);
             toast.show();
         }
-        else {
-            new FileCleanupTask(mainActivity, bloomBundleUri).execute();
-        }
+
+        new FileCleanupTask(mainActivity).execute(bundlesToCleanUp.toArray(new Uri[0]));
     }
 
     private void extractBloomBundle(Uri bloomBundleUri) throws IOException {

--- a/app/src/main/java/org/sil/bloom/reader/ImportBundleTask.java
+++ b/app/src/main/java/org/sil/bloom/reader/ImportBundleTask.java
@@ -62,18 +62,13 @@ public class ImportBundleTask extends AsyncTask<Uri, String, Void> {
             toast.show();
         }
         else {
-            try {
-                // We assume that they will be happy with us removing from where ever the bundle was,
-                // so long as it is on the same device (e.g. not coming from an sd card they plan to pass
-                // around the room).
-                if (!IOUtilities.seemToBeDifferentVolumes(bloomBundleUri.getPath(), getLocalBooksDirectory().getPath())) {
-                    (new File(bloomBundleUri.getPath())).delete();
-                }
+            // We assume that they will be happy with us removing from where ever the bundle was,
+            // so long as it is on the same device (e.g. not coming from an sd card they plan to pass
+            // around the room).
+            File bundleFile = new File(bloomBundleUri.getPath());
+            if (IOUtilities.isInNonRemovableStorage(mainActivity, bundleFile)) {
+                bundleFile.delete();
             }
-            catch (ExtStorageUnavailableException e) {
-                e.printStackTrace();
-            }
-
         }
     }
 

--- a/app/src/main/java/org/sil/bloom/reader/ImportBundleTask.java
+++ b/app/src/main/java/org/sil/bloom/reader/ImportBundleTask.java
@@ -62,13 +62,7 @@ public class ImportBundleTask extends AsyncTask<Uri, String, Void> {
             toast.show();
         }
         else {
-            // We assume that they will be happy with us removing from where ever the bundle was,
-            // so long as it is on the same device (e.g. not coming from an sd card they plan to pass
-            // around the room).
-            File bundleFile = new File(bloomBundleUri.getPath());
-            if (IOUtilities.isInNonRemovableStorage(mainActivity, bundleFile)) {
-                bundleFile.delete();
-            }
+            new FileCleanupTask(mainActivity, bloomBundleUri).execute();
         }
     }
 

--- a/app/src/main/java/org/sil/bloom/reader/models/BookCollection.java
+++ b/app/src/main/java/org/sil/bloom/reader/models/BookCollection.java
@@ -252,8 +252,9 @@ public class BookCollection {
             // We assume that they will be happy with us removing from where ever the file was,
             // so long as it is on the same device (e.g. not coming from an sd card they plan to pass
             // around the room).
-            if(!IOUtilities.seemToBeDifferentVolumes(bookUri.getPath(),destination)) {
-                (new File(bookUri.getPath())).delete();
+            File bookFile = new File(bookUri.getPath());
+            if (IOUtilities.isInNonRemovableStorage(context, bookFile)) {
+                bookFile.delete();
             }
 
             // it's probably not in our list that we display yet, so make an entry there

--- a/app/src/main/java/org/sil/bloom/reader/models/BookCollection.java
+++ b/app/src/main/java/org/sil/bloom/reader/models/BookCollection.java
@@ -250,8 +250,6 @@ public class BookCollection {
         String destination = mLocalBooksDirectory.getAbsolutePath() + File.separator + name;
         boolean copied = IOUtilities.copyFile(context, bookUri, destination);
         if(copied){
-            new FileCleanupTask(context, bookUri).execute();
-
             // it's probably not in our list that we display yet, so make an entry there
             addBookIfNeeded(destination);
             return destination;

--- a/app/src/main/java/org/sil/bloom/reader/models/BookCollection.java
+++ b/app/src/main/java/org/sil/bloom/reader/models/BookCollection.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 import org.sil.bloom.reader.BloomFileReader;
 import org.sil.bloom.reader.BloomReaderApplication;
 import org.sil.bloom.reader.BuildConfig;
+import org.sil.bloom.reader.FileCleanupTask;
 import org.sil.bloom.reader.IOUtilities;
 import org.sil.bloom.reader.ThumbnailCleanup;
 
@@ -249,13 +250,7 @@ public class BookCollection {
         String destination = mLocalBooksDirectory.getAbsolutePath() + File.separator + name;
         boolean copied = IOUtilities.copyFile(context, bookUri, destination);
         if(copied){
-            // We assume that they will be happy with us removing from where ever the file was,
-            // so long as it is on the same device (e.g. not coming from an sd card they plan to pass
-            // around the room).
-            File bookFile = new File(bookUri.getPath());
-            if (IOUtilities.isInNonRemovableStorage(context, bookFile)) {
-                bookFile.delete();
-            }
+            new FileCleanupTask(context, bookUri).execute();
 
             // it's probably not in our list that we display yet, so make an entry there
             addBookIfNeeded(destination);


### PR DESCRIPTION
I want to test this some more before it gets merged, but here's a first look.

Issue: https://issues.bloomlibrary.org/youtrack/issue/BL-6068

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/140)
<!-- Reviewable:end -->
