### PR TITLE
[BL-6652] Pass book path from MainActivity to ReaderActivity as string…

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/MainActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/MainActivity.java
@@ -499,7 +499,7 @@ public class MainActivity extends BaseActivity
             context.startActivity(intent);
         } else {
             Intent intent = new Intent(context, ReaderActivity.class);
-            intent.setData(Uri.parse(path));
+            intent.putExtra("bookPath", path);
             intent.putExtra("brandingProjectName", bookOrShelf.brandingProjectName);
             context.startActivity(intent);
         }

--- a/app/src/main/java/org/sil/bloom/reader/ReaderActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/ReaderActivity.java
@@ -172,7 +172,7 @@ public class ReaderActivity extends BaseActivity {
 
         @Override
         protected String doInBackground(Void... v) {
-            final String path = getIntent().getData().getPath();
+            final String path = getIntent().getStringExtra("bookPath");
             BloomFileReader fileReader = new BloomFileReader(getApplicationContext(), path);
             String bookDirectory;
             try {


### PR DESCRIPTION
Pass book path from MainActivity to ReaderActivity as string to avoid errors caused by Android Uri parsing.

Issue: https://issues.bloomlibrary.org/youtrack/issue/BL-6652

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/145)
<!-- Reviewable:end -->
