### PR TITLE
Remove intent-filter that opened up too much (BL-7045)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -165,8 +165,21 @@
                 MIME-type as empty string, which is only matchable with the most generic filter! The
                 other 3 filters all use both 'file' and 'content' scheme, but I don't want to put
                 'file' in this filter to keep from catching more than we absolutely have to.
+
+                The Samsung "My Files" app can establish a connection between .bloomd files and
+                Bloom Reader if the .bloomd file is on the device before Bloom Reader is installed.
+                Clicking on the file, then choosing "Search" from the popup warning dialog and
+                installing Bloom Reader establishes the connection.  This connection appears to
+                persist if Bloom Reader is then uninstalled and reinstalled.
+                I don't know if it can establish a connection to both .bloomd and .bloombundle
+                files, but possibly uninstalling it after getting the connection to one would allow
+                the user to reinstall and get a connection to the other without losing the first.
             -->
-            <intent-filter
+            <!-- This filter opens up Bloom Reader to offering to handle all sorts of files!  This
+                 is probably more confusing to more users than the workaround described above.
+                 See https://issues.bloomlibrary.org/youtrack/issue/BL-7045.
+            -->
+            <!--intent-filter
                 android:icon="@drawable/book"
                 android:label="@string/app_name">
                 <action android:name="android.intent.action.VIEW" />
@@ -178,7 +191,7 @@
                 <data android:host="*" />
 
                 <data android:mimeType="*/*" />
-            </intent-filter>
+            </intent-filter-->
         </activity>
         <activity
             android:name=".ReaderActivity"

--- a/app/src/main/java/org/sil/bloom/reader/MainActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/MainActivity.java
@@ -173,6 +173,7 @@ public class MainActivity extends BaseActivity
         Uri uri = intent.getData();
         if (uri == null || alreadyOpenedFileFromIntent)
             return;
+        Log.i("Intents", "processing "+intent.toString());
         String nameOrPath = uri.getPath();
         // Content URI's do not use the actual filename in the "path"
         if (uri.getScheme().equals("content")) {


### PR DESCRIPTION
The problem with the Samsung "My Files" app can be worked around by the
user.  If need be, we'll have to figure out how to explain it better than
my comments in the code and the issue indicated above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/172)
<!-- Reviewable:end -->
