### PR TITLE
Remove unreliable file descriptor operations (BL-7073)

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/IOUtilities.java
+++ b/app/src/main/java/org/sil/bloom/reader/IOUtilities.java
@@ -114,9 +114,8 @@ public class IOUtilities {
     }
 
     public static void unzip(Context context, Uri uri, File targetDirectory) throws IOException {
-        FileDescriptor fd = context.getContentResolver().openFileDescriptor(uri, "r").getFileDescriptor();
-        ZipInputStream zis = new ZipInputStream(
-                new BufferedInputStream(new FileInputStream(fd)));
+        InputStream fs = context.getContentResolver().openInputStream(uri);
+        ZipInputStream zis = new ZipInputStream(new BufferedInputStream(fs));
         unzip(zis, targetDirectory);
     }
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/20080171/contentresolver-openfiledescriptor-does-not-call-contentprovider-openfile
for why these changes are needed and appropriate.  A similar change has
already been made to IOUtilities.copyBloomdFile(context, uri, toPath).
(This method used to be called copyFile, but is used only for copying
.bloomd files, so now has an added check in it.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/175)
<!-- Reviewable:end -->
