### PR TITLE
Fix proguard-rules.pro to allow compilation of updated commons compress library (BL-7421)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -37,12 +37,12 @@
 -dontwarn org.apache.commons.compress.archivers.sevenz.*
 -dontwarn org.apache.commons.compress.archivers.zip.*
 -dontwarn org.apache.commons.compress.compressors.brotli.BrotliCompressorInputStream
--dontwarn org.apache.commons.compress.compressors.lzma.LZMACompressorInputStream
+-dontwarn org.apache.commons.compress.compressors.lzma.*
 -dontwarn org.apache.commons.compress.compressors.pack200.TempFileCachingStreamBridge
 -dontwarn org.apache.commons.compress.compressors.xz.*
+-dontwarn org.apache.commons.compress.compressors.zstandard.*
 -dontwarn org.apache.commons.compress.parallel.*
 -dontwarn org.apache.commons.compress.utils.*
--dontwarn org.apache.commons.compress.compressors.lzma.LZMACompressorOutputStream
 
 # We're not hiding anything...we're open source!
 -dontobfuscate


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/206)
<!-- Reviewable:end -->
