### PR TITLE
Move to targeting Android 10, with legacy storage access

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 // This is the master definition of what version of Bloom Reader we are building
 def versionMajor = 2
-def versionMinor = 2
+def versionMinor = 3
 def versionRelease = getVersionRelease()
 
 int getVersionRelease() {
@@ -29,12 +29,12 @@ android {
      * compile your app. This means your app can use the API features included in
      * this API level and lower.
      */
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "org.sil.bloom.reader"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode versionMajor * 100000 + versionMinor * 1000 + versionRelease.toInteger()
         versionName "${versionMajor}.${versionMinor}.${versionRelease}"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
 
     <application
         android:name=".BloomReaderApplication"
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/org/sil/bloom/reader/MainActivity.java
+++ b/app/src/main/java/org/sil/bloom/reader/MainActivity.java
@@ -782,6 +782,14 @@ public class MainActivity extends BaseActivity
                 Intent intent = new Intent(this, GetFromWiFiActivity.class);
                 this.startActivityForResult(intent, DOWNLOAD_BOOKS_REQUEST);
                 break;
+            case R.id.nav_get_usb:
+                final AlertDialog d = new AlertDialog.Builder(this, R.style.SimpleDialogTheme)
+                        .setPositiveButton(android.R.string.ok, null)
+                        .setTitle(getString(R.string.receive_books_over_usb))
+                        .setMessage(getString(R.string.ready_to_receive_usb))
+                        .create();
+                d.show();
+                break;
             case R.id.nav_share_app:
                 ShareDialogFragment shareDialogFragment = new ShareDialogFragment();
                 shareDialogFragment.show(getFragmentManager(), ShareDialogFragment.SHARE_DIALOG_FRAGMENT_TAG);

--- a/app/src/main/res/drawable/ic_baseline_usb_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_usb_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15,7v4h1v2h-3V5h2l-3,-4 -3,4h2v8H8v-2.07c0.7,-0.37 1.2,-1.08 1.2,-1.93 0,-1.21 -0.99,-2.2 -2.2,-2.2 -1.21,0 -2.2,0.99 -2.2,2.2 0,0.85 0.5,1.56 1.2,1.93V13c0,1.11 0.89,2 2,2h3v3.05c-0.71,0.37 -1.2,1.1 -1.2,1.95 0,1.22 0.99,2.2 2.2,2.2 1.21,0 2.2,-0.98 2.2,-2.2 0,-0.85 -0.49,-1.58 -1.2,-1.95V15h3c1.11,0 2,-0.89 2,-2v-2h1V7h-4z"/>
+</vector>

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -7,6 +7,10 @@
             android:id="@+id/nav_get_wifi"
             android:icon="@drawable/ic_wifi_black_24dp"
             android:title="@string/receive_books_over_wifi" />
+        <item
+            android:id="@+id/nav_get_usb"
+            android:icon="@drawable/ic_baseline_usb_24"
+            android:title="@string/receive_books_over_usb" />
         <!--item
             android:id="@+id/nav_catalog"
             android:icon="@drawable/ic_menu_get_books"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,7 +66,11 @@
     <string name="about_bloom">About Bloom</string>
     <string name="about_sil">About SIL</string>
     <string name="or">or</string>
-    <string name="receive_books_over_wifi">Receive books from computer</string>
+    <!-- Prior to BR 2.3, this message was "Receive books from computer"-->
+    <string name="receive_books_over_wifi">Receive books via WiFi</string>
+    <!-- Used both as a menu option and as the title of the resulting dialog-->
+    <string name="receive_books_over_usb">Receive books via USB</string>
+    <string name="ready_to_receive_usb">Bloom Reader is ready to receive books via USB cable from the Bloom Editor program</string>
 
     <string name="bloomReaderUrl" translatable="false"><u>bloomlibrary.org</u></string>
 


### PR DESCRIPTION
Anticipating Android 11, we add a menu option to "Receive books via USB", though for now it just shows a dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomreader/253)
<!-- Reviewable:end -->
