### PR TITLE
Use ICU sort for book titles in book list (BL-14289)

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/models/AlphanumComparator.java
+++ b/app/src/main/java/org/sil/bloom/reader/models/AlphanumComparator.java
@@ -32,6 +32,9 @@ package org.sil.bloom.reader.models;
  */
 
 import java.util.Comparator;
+import java.util.Locale;
+import android.icu.text.Collator;
+import android.os.Build;
 
 /**
  * This is an updated version with enhancements made by Daniel Migowski,
@@ -44,6 +47,16 @@ import java.util.Comparator;
  *   Collections.sort(your list, new AlphanumComparator());
  */
 public class AlphanumComparator implements Comparator<BookOrShelf> {
+
+    private static Collator sIcuCollator = null;
+
+    static {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            sIcuCollator = Collator.getInstance(Locale.ROOT);
+            sIcuCollator.setStrength(Collator.SECONDARY);
+        }
+    }
+
     private final boolean isDigit(char ch) {
         return ((ch >= 48) && (ch <= 57)); // Digits 0 through 9
     }
@@ -177,7 +190,11 @@ public class AlphanumComparator implements Comparator<BookOrShelf> {
                     }
                 }
             } else {
-                result = thisChunk.compareToIgnoreCase(thatChunk);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    result = sIcuCollator.compare(thisChunk, thatChunk);
+                } else {
+                    result = thisChunk.compareToIgnoreCase(thatChunk);
+                }
             }
 
             if (result != 0)

--- a/app/src/test/java/org/sil/bloom/reader/models/BookOrShelfTest.java
+++ b/app/src/test/java/org/sil/bloom/reader/models/BookOrShelfTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class BookOrShelfTest {
 
     @Test
-    public void alphabeticalComparator_sortsAlphabetically() {
+    public void alphanumComparator_sortsAlphabetically() {
 
         List<BookOrShelf> books = Arrays.asList(
                 new BookOrShelf("/dummypath/c"),
@@ -27,7 +27,7 @@ public class BookOrShelfTest {
     }
 
     @Test
-    public void alphabeticalComparator_edgeCases_sortsAlphabeticallyWithNullsLast() {
+    public void alphanumComparator_edgeCases_sortsAlphabeticallyWithNullsLast() {
 
         List<BookOrShelf> books = Arrays.asList(
                 new BookOrShelf("z", null),
@@ -71,4 +71,38 @@ public class BookOrShelfTest {
         assertThat(books.get(3).name, is("12bob"));
         assertThat(books.get(4).name, is("bob"));
     }
+
+    // I've spent almost a day (maybe more?) trying to get this unit test to work.
+    // At this point, I'm giving up and saying it isn't worth it.
+    // Complication 1: gated code in AlphanumComparator for the SDK version.
+    //  When running unit tests, Build.Version.SDK_INT is 0.
+    //  I tried
+    //  1. setting the SDK_INT via reflection
+    //  2. mocking a wrapper around Build.VERSION.SDK_INT
+    //  3. an "if" condition in production code which checks if we are running unit tests
+    // Complication 2:
+    //  Even when it was possible to get the correct production code to run,
+    //  the unit test fails with "java.lang.RuntimeException: Method getInstance in android.icu.text.Collator not mocked."
+    //  Turns out, you can't use the real ICU collator in unit tests. We could mock the collator,
+    //  but that's basically working around the whole point of this test.
+//    @Test
+//    public void alphanumComparator_sortsUnicodeIntelligently() {
+//
+//        List<BookOrShelf> books = Arrays.asList(
+//                new BookOrShelf("/dummypath/Huɛɲɔ̃"),
+//                new BookOrShelf("/dummypath/Hããsiekɔluwɔ"),
+//                new BookOrShelf("/dummypath/Nuɔ̃kɔ"),
+//                new BookOrShelf("/dummypath/Sɛ̃cɔ"),
+//                new BookOrShelf("/dummypath/Vasirɔ biɛ̃ŋɔ̃"),
+//                new BookOrShelf("/dummypath/Ɲĩbũmɔ̃")
+//        );
+//
+//        Collections.sort(books, BookOrShelf.AlphanumComparator);
+//
+//        List<String> expectedNames =
+//                Arrays.asList("Hããsiekɔluwɔ", "Huɛɲɔ̃", "Nuɔ̃kɔ", "Ɲĩbũmɔ̃", "Sɛ̃cɔ", "Vasirɔ biɛ̃ŋɔ̃");
+//
+//        List<String> actualNames = books.stream().map(book -> book.name).collect(Collectors.toList());
+//        assertThat(actualNames, is(expectedNames));
+//    }
 }


### PR DESCRIPTION
Note that Android < 7.0 will still use the old sort since ICU was introduced in Android in 7.0 (api 24).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomReader/313)
<!-- Reviewable:end -->
