### PR TITLE
Book request: remove deprecated AsyncTask

### DIFF
--- a/app/src/main/java/org/sil/bloom/reader/wifi/NewBookListenerService.java
+++ b/app/src/main/java/org/sil/bloom/reader/wifi/NewBookListenerService.java
@@ -215,9 +215,6 @@ public class NewBookListenerService extends Service {
         // Send one package to the desktop to request the book. Its contents tell the desktop
         // what IP address to use.
 
-        // SendMessage is a deprecated class as of API level 30.
-        // For an alternative use a Socket, which allows the associated IP address to be specified.
-        //
         // Create and bind the UDP socket here and send the UDP packet.
         // It will be on the same thread but that should be fine -- NewBookListenerService doesn't
         // have anything better to do. We're making a book request so there is no need to quickly


### PR DESCRIPTION
I have not observed a failure with Reader sending a book request to Desktop, but the mechanism that does this extends a class (AsyncTask) that is deprecated as of API level 30. This changeset offers an alternative implementation. It's mostly the same stuff - UDP socket and JSON book request - but is just lifted out of the extended AsyncTask class. I could not see the need for the extra layer and extra thread, as the main thread does not need to resume listening for adverts after making a book request.

I left in some debug output code to log the content of the book advert received from Desktop. It is commented out. I have found this very useful, but it should probably be deleted in production code. Perhaps the same will be true of the handful of other lines, still uncommented, showing the progress of an advert's reception and processing. But I would encourage that they be retained if possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomReader/326)
<!-- Reviewable:end -->
