### PR TITLE
Add GitHub Actions workflow to publish to Play Console internal track

### DIFF
--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -1,0 +1,257 @@
+# Publishes Bloom Reader to the Google Play Console (internal track).
+#
+# - Pushes to `master`  -> alpha flavor      -> internal track of the "BR Alpha" app
+# - Pushes to `release` -> production flavor -> internal track of the "Bloom Reader" app
+#
+# (The Play track is set to "internal" in app/build.gradle's `play {}` block;
+# promotion to other tracks is done manually in the Play Console or via the
+# promote*Artifact gradle tasks.)
+#
+# Required repository secrets:
+#   KEYSTORE_BASE64            base64 of keystore_bloom_reader.keystore
+#                              (e.g. `base64 -w0 keystore_bloom_reader.keystore`)
+#   KEYSTORE_STORE_PASSWORD    storePassword from keystore_bloom_reader.properties
+#   KEYSTORE_KEY_ALIAS         keyAlias from keystore_bloom_reader.properties
+#   KEYSTORE_KEY_PASSWORD      keyPassword from keystore_bloom_reader.properties
+#   PLAY_SERVICE_ACCOUNT_JSON  contents of the Google Play service account json file
+#   BLOOMLIBRARY_AWS_ACCESS_KEY_ID     credentials of the BloomLibrary AWS profile,
+#   BLOOMLIBRARY_AWS_SECRET_ACCESS_KEY used to upload the production APK and
+#                              version file to the bloomlibrary.org S3 bucket
+#
+# Optional repository variable:
+#   PLAY_DRY_RUN               set to "true" to build, sign, and upload to a Play
+#                              edit WITHOUT committing it — nothing becomes
+#                              visible in the Play Console. Use while verifying
+#                              this workflow; delete the variable to go live.
+#
+# Versioning: the patch number (3.4.NNN) is the number of commits since
+# versionMajor/versionMinor last changed in app/build.gradle, so it resets to 0
+# automatically when the version is bumped, and master (alpha) and release
+# (production) count independently. NOTE: build.gradle computes versionCode =
+# major*100000 + minor*1000 + patch, so patch must stay below 1000.
+
+name: Publish to Play Console
+
+on:
+  push:
+    branches: [master, release]
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: "Flavor to publish (both go to the internal track)"
+        type: choice
+        options: [Alpha, Production]
+        default: Alpha
+      patch:
+        description: "Override the patch number (default: commits since the last version bump, plus the +77 legacy alpha offset)"
+        type: string
+        required: false
+        default: ""
+
+# Never run two publishes at once; Play edits would race.
+concurrency:
+  group: play-publish
+  cancel-in-progress: false
+
+# contents: write lets the workflow push the release tag.
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history: the patch number is derived from it
+          fetch-tags: true # the tag step checks for existing release tags
+
+      - name: Determine flavor and build number
+        id: config
+        env:
+          PATCH_INPUT: ${{ inputs.patch }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            FLAVOR="${{ inputs.flavor }}"
+          elif [ "${{ github.ref }}" = "refs/heads/release" ]; then
+            FLAVOR="Production"
+          else
+            FLAVOR="Alpha"
+          fi
+          # Normalize the dry-run flag once; everything downstream uses the
+          # dry_run output so shell, gradle, and expression contexts cannot
+          # disagree (e.g. on a value like "True").
+          DRY_RUN=$(echo "${{ vars.PLAY_DRY_RUN }}" | tr '[:upper:]' '[:lower:]')
+          [ "$DRY_RUN" = "true" ] || DRY_RUN=false
+          echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+          # A real publish must run from the flavor's own branch: the two
+          # branches have different commit counts, so publishing a flavor
+          # from the wrong branch corrupts that app's version numbering.
+          # Dry runs commit nothing to Play and may run from any branch.
+          if [ "$DRY_RUN" != "true" ]; then
+            if [ "$FLAVOR" = "Production" ] && [ "${{ github.ref }}" != "refs/heads/release" ]; then
+              echo "::error::A real Production publish must run from the release branch."
+              exit 1
+            fi
+            if [ "$FLAVOR" = "Alpha" ] && [ "${{ github.ref }}" != "refs/heads/master" ]; then
+              echo "::error::A real Alpha publish must run from the master branch."
+              exit 1
+            fi
+          fi
+          # The patch number counts commits since the last version bump (the
+          # last commit that changed the versionMajor/versionMinor lines in
+          # app/build.gradle), so bumping the version resets it to 0 on its
+          # own, and master (alpha) and release (production) count
+          # independently on their own branches.
+          if [ -n "$PATCH_INPUT" ]; then
+            if ! [[ "$PATCH_INPUT" =~ ^[0-9]+$ ]]; then
+              echo "::error::patch must be a plain number, got: $PATCH_INPUT"
+              exit 1
+            fi
+            BUILD_NUMBER="$PATCH_INPUT"
+          else
+            BUMP_COMMIT=$(git log -1 --format=%H -G'^def version(Major|Minor)' -- app/build.gradle)
+            if [ -z "$BUMP_COMMIT" ]; then
+              # Without this guard, an empty BUMP_COMMIT would make rev-list
+              # silently count 0 and publish a bogus x.y.0.
+              echo "::error::Could not find the version bump commit in app/build.gradle history."
+              exit 1
+            fi
+            BUILD_NUMBER=$(git rev-list --count "$BUMP_COMMIT..HEAD")
+            # Continuity with the old TeamCity build counter (alpha was at
+            # 3.4.103 when this workflow took over). Keyed to the 3.4 bump
+            # commit, so it expires by itself: the next version bump becomes
+            # the new BUMP_COMMIT and this no longer applies.
+            if [ "$BUMP_COMMIT" = "06dc6358a9a2ea410d5ce9bf6b39474177461618" ] && [ "$FLAVOR" = "Alpha" ]; then
+              BUILD_NUMBER=$(( BUILD_NUMBER + 77 ))
+            fi
+          fi
+          if [ "$BUILD_NUMBER" -gt 999 ]; then
+            echo "::error::patch $BUILD_NUMBER would overflow into the minor-version digits of versionCode"
+            exit 1
+          fi
+          # Gradle task lists mirror the TeamCity builds ("clean" omitted:
+          # the build dir doesn't exist on a fresh runner), plus the publish
+          # step. TC's production build stops at assemble (publishing was a
+          # separate manual step); here publishProductionRelease assembles
+          # and publishes to the internal track.
+          if [ "$FLAVOR" = "Alpha" ]; then
+            # The full "build" deliberately compiles, lints, and unit-tests
+            # every flavor and build type — each alpha run verifies that
+            # nothing is broken even in the variants we don't publish.
+            TASKS="build publishAlphaRelease promoteAlphaReleaseArtifact"
+          else
+            # APK-only for production: the "Bloom Reader" store listing is
+            # managed in the Play Console, and the listing text/graphics in
+            # app/src/main/play are years stale — a full publish task would
+            # overwrite the live listing with them.
+            TASKS="lintProductionRelease testProductionReleaseUnitTest publishProductionReleaseApk"
+          fi
+          MAJOR=$(sed -n 's/^def versionMajor = \([0-9]*\).*/\1/p' app/build.gradle)
+          MINOR=$(sed -n 's/^def versionMinor = \([0-9]*\).*/\1/p' app/build.gradle)
+          echo "flavor=$FLAVOR" >> "$GITHUB_OUTPUT"
+          echo "flavor_lc=${FLAVOR,,}" >> "$GITHUB_OUTPUT"
+          echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "version=$MAJOR.$MINOR.$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "tasks=$TASKS" >> "$GITHUB_OUTPUT"
+          echo "Publishing flavor $FLAVOR version $MAJOR.$MINOR.$BUILD_NUMBER (tasks: $TASKS)"
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: app/yarn.lock
+
+      - name: Install bloom-player
+        working-directory: app
+        run: yarn install --frozen-lockfile
+
+      # Alpha builds always ship the latest alpha of bloom-player;
+      # production builds use the version locked in yarn.lock.
+      - name: Upgrade to latest bloom-player alpha
+        if: steps.config.outputs.flavor == 'Alpha'
+        working-directory: app
+        run: yarn upgrade bloom-player@alpha
+
+      - name: Set up signing and Play credentials
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+          KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          # app/build.gradle reads ~/keystore/keystore_bloom_reader.properties
+          mkdir -p "$HOME/keystore"
+          echo "$KEYSTORE_BASE64" | base64 -d > "$HOME/keystore/keystore_bloom_reader.keystore"
+          printf '%s' "$PLAY_SERVICE_ACCOUNT_JSON" > "$HOME/keystore/play-service-account.json"
+          cat > "$HOME/keystore/keystore_bloom_reader.properties" <<EOF
+          storeFile=$HOME/keystore/keystore_bloom_reader.keystore
+          storePassword=$KEYSTORE_STORE_PASSWORD
+          keyAlias=$KEYSTORE_KEY_ALIAS
+          keyPassword=$KEYSTORE_KEY_PASSWORD
+          serviceAccountJsonFile=$HOME/keystore/play-service-account.json
+          EOF
+
+      - name: Copy bloom-player assets
+        run: ./gradlew copyBloomPlayerAssets
+
+      - name: Build and publish to internal track
+        run: >
+          ./gradlew ${{ steps.config.outputs.tasks }}
+          "-Pbuild.number=${{ steps.config.outputs.build_number }}"
+          "-PplayDryRun=${{ steps.config.outputs.dry_run }}"
+
+      # bloomlibrary.org serves the production APK for direct download and
+      # reads the version file to know the latest version. Only reached if
+      # the publish above succeeded. Requiring the release ref (redundant
+      # with the branch guard above) keeps public-facing artifacts off any
+      # other branch, e.g. during workflow testing.
+      - name: Upload APK and version file to bloomlibrary.org S3
+        if: steps.config.outputs.flavor == 'Production' && steps.config.outputs.dry_run == 'false' && github.ref == 'refs/heads/release'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.BLOOMLIBRARY_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.BLOOMLIBRARY_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          printf '%s' "${{ steps.config.outputs.version }}" > bloomReaderVersionNumber.txt
+          aws s3 cp app/build/outputs/apk/production/release/app-production-release.apk \
+            s3://bloomlibrary.org/bloomReader/apks/release/latest/BloomReader.apk
+          aws s3 cp bloomReaderVersionNumber.txt \
+            s3://bloomlibrary.org/assets/bloomReaderVersionNumber.txt
+
+      # Only reached if the publish above succeeded. Release ref required
+      # for the same reason as the S3 step.
+      - name: Tag the released commit
+        if: steps.config.outputs.flavor == 'Production' && steps.config.outputs.dry_run == 'false' && github.ref == 'refs/heads/release'
+        run: |
+          TAG="v${{ steps.config.outputs.version }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            if [ "$(git rev-parse "refs/tags/$TAG^{commit}")" = "$(git rev-parse HEAD)" ]; then
+              echo "Tag $TAG already exists on this commit (re-run); nothing to do."
+              exit 0
+            fi
+            echo "::error::Tag $TAG already exists on a different commit."
+            exit 1
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Clean up credentials
+        if: always()
+        run: rm -rf "$HOME/keystore"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: bloomreader-${{ steps.config.outputs.flavor }}-${{ steps.config.outputs.build_number }}
+          # The build task assembles every flavor; only keep the one published.
+          path: app/build/outputs/apk/${{ steps.config.outputs.flavor_lc }}/release/*.apk
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ At this point, anyone can publish a book using the existing Bloom mechanism, and
 ## Getting the Bloom Reader code dependencies
 
 BloomReader requires a number of files from the [bloom-player](https://github.com/BloomBooks/bloom-player.git) project. By default,
-and in the TeamCity build, these are obtained using yarn from the npm output of bloom-player.
+and in the CI build, these are obtained using yarn from the npm output of bloom-player.
 
 When building locally, if you need to make changes to bloom-player, you can use `yarn link`.
 
@@ -118,11 +118,14 @@ file to update the version number of bloom-player if needed.
 
 ## Flavors
 
-We build three flavors of the app:
+We build two flavors of the app:
 
 - alpha (`org.sil.bloom.reader.alpha`)
-- beta (`org.sil.bloom.reader.beta`)
 - production (`org.sil.bloom.reader`)
+
+(There was formerly a beta flavor (`org.sil.bloom.reader.beta`), but the Play
+Store shut down the BR Beta app; its definition is commented out in
+app/build.gradle.)
 
 ## Debug builds
 
@@ -144,9 +147,9 @@ The contents of this file are:
 
 where `storeFile` is an absolute path to `keystore_bloom_reader.keystore`. This file and the other values must be shared with you by a member of the team who has them.
 
-## TeamCity builds (and deploying to the Play Store)
+## Deploying to the Play Store
 
-To publish to the Play Store, we use a gradle plugin: `https://github.com/Triple-T/gradle-play-publisher`. To use the plugin, you must add `serviceAccountJsonFile=` to the `.properties` file described above. Set the value as an absolute path to the `Google Play Android Developer-cf6d1afc73be.json` file which you must obtain from a member of the team.
+To publish to the Play Store, we use a gradle plugin: `https://github.com/Triple-T/gradle-play-publisher`. To use the plugin locally, you must add `serviceAccountJsonFile=` to the `.properties` file described above. Set the value as an absolute path to the `Google Play Android Developer-cf6d1afc73be.json` file which you must obtain from a member of the team.
 
 Gradle tasks which can be called with the plugin include:
 
@@ -157,13 +160,68 @@ Gradle tasks which can be called with the plugin include:
 - publish{Alpha/Beta/Production}ReleaseListing
   - pushes only the listing metadata to the Play Store
 
-TeamCity builds are configured to publish the alpha, beta, and production flavors to three respective apps on the Play Store.
+### CI/CD (GitHub Actions)
 
-- The alpha build is a continuous publish to the internal test and alpha tracks of the "BR Alpha" app.
-- The beta build is a manual publish to the internal test and beta tracks of the "BR Beta" app.
-- The production build is a manual publish to the internal test track of the "Bloom Reader" app. Currently, releases need to be promoted to production manually in the Play Console.
+Publishing is automated by the GitHub Actions workflow
+[.github/workflows/play-publish.yml](.github/workflows/play-publish.yml):
 
-The `ba-bloom-win10` (in the Bloom pool) is currently the only agent configured with the `.properties` file described above.
+- Every push to `master` builds the **alpha** flavor — first upgrading to the
+  latest `bloom-player@alpha` — runs the full `build` (deliberately compiling,
+  linting, and unit-testing every flavor and build type, so each alpha run
+  verifies nothing is broken even in variants we don't publish), publishes to
+  the internal track of the "BR Alpha" Play app, and then promotes it per the
+  `play {}` config in app/build.gradle.
+- Every push to `release` runs lint and unit tests, builds the **production**
+  flavor (using the bloom-player version pinned in app/yarn.lock), publishes
+  the APK (only — the store listing is managed in the Play Console, not the
+  repo) to the internal track of the "Bloom Reader" Play app, uploads the APK
+  and a version-number file to the bloomlibrary.org S3 bucket (which serves
+  the APK for direct download), and tags the commit `vX.Y.Z`. Promoting from
+  the internal track to production is still a manual step in the Play Console.
+- The workflow can also be dispatched manually from the Actions tab (choose a
+  flavor; optionally override the patch number). A real publish must be
+  dispatched from the flavor's own branch; dry runs may run from any branch.
+
+#### Version numbers
+
+`versionMajor` and `versionMinor` are defined in app/build.gradle. CI derives
+the patch number (the x in 3.4.x) by counting the commits since the last
+commit that changed those two lines. Consequences:
+
+- Bumping the version resets the patch to 0 automatically — to start 3.5,
+  just change `versionMinor` and commit. (But don't touch those lines for any
+  other reason, e.g. reformatting: that also resets the patch counter.)
+- `master` (alpha) and `release` (production) have independent patch numbers.
+- versionCode = major\*100000 + minor\*1000 + patch, so the patch must stay
+  below 1000; the workflow fails if it would overflow.
+- Until the next version bump, alpha patch numbers include a hardcoded +77
+  offset for continuity with the old TeamCity build counter. It is keyed to
+  the 3.4 bump commit and expires on its own (see the workflow).
+
+#### The legacy 1.4 APK
+
+Every production release retains the legacy 1.4 APK (versionCode 104001) so
+that devices below the current minSdkVersion keep a working app (see
+`playConfigs` in app/build.gradle). A production release must never be
+published without it: re-adding an APK that targets an old API level may not
+be possible under current Play requirements.
+
+#### Secrets and configuration
+
+The workflow requires these GitHub repository secrets:
+
+- `KEYSTORE_BASE64` — base64 of `keystore_bloom_reader.keystore`
+- `KEYSTORE_STORE_PASSWORD`, `KEYSTORE_KEY_ALIAS`, `KEYSTORE_KEY_PASSWORD` —
+  the corresponding values from `keystore_bloom_reader.properties`
+- `PLAY_SERVICE_ACCOUNT_JSON` — the contents of the service account json file
+- `BLOOMLIBRARY_AWS_ACCESS_KEY_ID`, `BLOOMLIBRARY_AWS_SECRET_ACCESS_KEY` —
+  credentials of the BloomLibrary AWS profile, used to upload the production
+  APK and version file to the bloomlibrary.org S3 bucket
+
+Setting the repository **variable** `PLAY_DRY_RUN` to `true` makes every run
+build, sign, and upload to a Play edit without committing it, so nothing
+becomes visible in the Play Console. Use it when verifying changes to the
+workflow; delete the variable to resume real publishing.
 
 # Localization
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,9 @@ plugins {
 }
 
 // This is the master definition of what version of Bloom Reader we are building
+// NOTE: CI derives the patch number by counting commits since the last commit
+// that changed the two lines below, so any edit to them (even reformatting)
+// resets the published patch number to 0. Touch them only to bump the version.
 def versionMajor = 3
 def versionMinor = 4
 def versionRelease = getVersionRelease()
@@ -80,12 +83,14 @@ android {
             signingConfig signingConfigs.release
             dimension 'default'
         }
-        beta {
-            applicationIdSuffix ".beta"
-            versionNameSuffix "-beta"
-            signingConfig signingConfigs.release
-            dimension 'default'
-        }
+        // We don't currently publish a beta; the Play Store shut down the
+        // BR Beta app. Restore this block if that ever changes.
+        // beta {
+        //     applicationIdSuffix ".beta"
+        //     versionNameSuffix "-beta"
+        //     signingConfig signingConfigs.release
+        //     dimension 'default'
+        // }
         production {
             // no id or version name suffix; this is the main product.
             signingConfig signingConfigs.release
@@ -108,6 +113,21 @@ android {
         // Used for the promote*Artifact tasks
         fromTrack = "internal"
         promoteTrack = "beta"
+
+        // CI passes -PplayDryRun=true to build, sign, and upload to a Play
+        // edit without committing it, so nothing changes in the Play Console.
+        commit = findProperty('playDryRun') != 'true'
+    }
+
+    playConfigs {
+        production {
+            // Each production release must continue to offer the legacy 1.4
+            // build (versionCode 104001) so devices below our current
+            // minSdkVersion keep getting a working app. Retaining it here
+            // means every publish includes it automatically instead of
+            // relying on a manual step in the Play Console.
+            retain.artifacts = [104001L]
+        }
     }
 
     testOptions {
@@ -119,6 +139,31 @@ android {
     namespace 'org.sil.bloom.reader'
     buildFeatures {
         buildConfig true
+    }
+}
+
+// Fail any production publish that is not going to retain the legacy 1.4 APK
+// (see the playConfigs block above) rather than let a release silently drop
+// it -- e.g. if a gradle-play-publisher upgrade changes how retain is
+// configured or applied. This reads the merged config off the publish task
+// itself (the value the task will actually use). The hasProperty filter
+// skips the plugin's plain "...Wrapper" companion tasks, which carry no
+// config; the isEmpty check keeps this loud if a plugin upgrade renames
+// everything and the filter no longer matches any task at all.
+project.afterEvaluate {
+    def guarded = tasks.findAll {
+        it.name.startsWith('publishProduction') && it.hasProperty('extension')
+    }
+    if (guarded.isEmpty()) {
+        throw new GradleException("Found no gradle-play-publisher production publish tasks to guard. Did a plugin upgrade change task or property names? Update the legacy-1.4-APK retain check (near playConfigs in app/build.gradle) to match.")
+    }
+    guarded.each { task ->
+        task.doFirst {
+            def retained = task.extension.retain.artifacts
+            if (retained == null || !retained.contains(104001L)) {
+                throw new GradleException("${task.name} is not configured to retain the legacy 1.4 APK (versionCode 104001). See playConfigs in app/build.gradle.")
+            }
+        }
     }
 }
 
@@ -195,4 +240,4 @@ project.afterEvaluate {
 //    preBuild.dependsOn copyBloomPlayerAssets
 //}
 // But, if we do that, we can't overwrite the bloom-player assets temporarily for testing versions under development.
-// Instead, TeamCity will need build steps to cd app, yarn, cd .., "gradle copyBloomPlayerAssets"
+// Instead, the CI build needs steps to cd app, yarn, cd .., "gradle copyBloomPlayerAssets"

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "//": "Developers need to `yarn upgrade bloom-player` to get the latest, because of yarn.lock. (TeamCity does this automatically.)",
+    "//": "Developers need to `yarn upgrade bloom-player` to get the latest, because of yarn.lock. (CI alpha builds do this automatically.)",
     "bloom-player": "^2.20.1"
   },
   "scripts": {},


### PR DESCRIPTION
Pushes to master publish the alpha flavor (with the latest bloom-player
alpha); pushes to release publish the production flavor. Both go to the
internal track via gradle-play-publisher.

- Alpha mirrors the old TeamCity build: full build (lint, unit tests,
  all variants), publish to the BR Alpha app's internal track including
  the repo-managed listing, then promote per the play {} config.
- Production runs lint and unit tests, then publishes the APK only --
  the Bloom Reader store listing is managed in the Play Console, and
  the listing text in app/src/main/play is years stale. A successful
  production publish tags the commit (vX.Y.Z).
- Production releases retain the legacy 1.4 APK (versionCode 104001)
  so devices below the current minSdkVersion keep a working app; this
  removes the reason production publishing had to stay manual.
- The patch number is derived from git: commits since the last change
  to versionMajor/versionMinor in app/build.gradle. It resets to 0
  automatically on a version bump; alpha and production count
  independently on their branches. A hardcoded offset keyed to the 3.4
  bump commit keeps continuity with the old TeamCity counter and
  expires on its own at the next version bump.
- The PLAY_DRY_RUN repo variable makes runs upload to a Play edit
  without committing it, for verifying the workflow safely.
- README updated to describe the new CI/CD process.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomReader/329)
<!-- Reviewable:end -->
