### PR TITLE
Auto-resolve alpha version collisions on commit-less rebuilds

### DIFF
--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -27,11 +27,12 @@
 # Versioning: the patch number (3.4.NNN) is the number of commits since
 # versionMajor/versionMinor last changed in app/build.gradle, so it resets to 0
 # automatically when the version is bumped, and master (alpha) and release
-# (production) count independently. Alpha additionally floors its number at
-# (Play's highest uploaded versionCode + 1), so rebuilds with no new commit
-# (e.g. dispatched after a bloom-player update) still publish. NOTE:
-# build.gradle computes versionCode = major*100000 + minor*1000 + patch, so
-# patch must stay below 1000.
+# (production) count independently. For alpha, gradle-play-publisher's
+# resolutionStrategy AUTO (see playConfigs in app/build.gradle) additionally
+# floors the published versionCode at (Play's highest uploaded code + 1), so
+# rebuilds with no new commit (e.g. dispatched after a bloom-player update)
+# still publish. NOTE: build.gradle computes versionCode = major*100000 +
+# minor*1000 + patch, so patch must stay below 1000.
 
 name: Publish to Play Console
 
@@ -112,7 +113,6 @@ jobs:
               exit 1
             fi
             BUILD_NUMBER="$PATCH_INPUT"
-            echo "patch_overridden=true" >> "$GITHUB_OUTPUT"
           else
             BUMP_COMMIT=$(git log -1 --format=%H -G'^def version(Major|Minor)' -- app/build.gradle)
             if [ -z "$BUMP_COMMIT" ]; then
@@ -136,7 +136,7 @@ jobs:
             # The full "build" deliberately compiles, lints, and unit-tests
             # every flavor and build type — each alpha run verifies that
             # nothing is broken even in the variants we don't publish.
-            TASKS="build publishAlphaRelease promoteAlphaReleaseArtifact"
+            TASKS="build publishAlphaReleaseApps promoteAlphaReleaseArtifact"
           else
             # APK-only for production: the "Bloom Reader" store listing is
             # managed in the Play Console, and the listing text/graphics in
@@ -148,8 +148,6 @@ jobs:
           MINOR=$(sed -n 's/^def versionMinor = \([0-9]*\).*/\1/p' app/build.gradle)
           echo "flavor=$FLAVOR" >> "$GITHUB_OUTPUT"
           echo "flavor_lc=${FLAVOR,,}" >> "$GITHUB_OUTPUT"
-          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
-          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
           echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
           echo "tasks=$TASKS" >> "$GITHUB_OUTPUT"
           echo "Derived version $MAJOR.$MINOR.$BUILD_NUMBER for flavor $FLAVOR (tasks: $TASKS)"
@@ -197,79 +195,27 @@ jobs:
           keyPassword=$KEYSTORE_KEY_PASSWORD
           serviceAccountJsonFile=$HOME/keystore/play-service-account.json
           EOF
-
-      # Alpha is sometimes rebuilt with no new commit (e.g. when a
-      # bloom-player update dispatches this workflow), which would reuse the
-      # same derived patch number and be rejected by Play as a duplicate
-      # versionCode. Ask Play for the highest versionCode already uploaded to
-      # the alpha app and use max(derived, highest + 1).
-      # (gradle-play-publisher 2.8's built-in resolutionStrategy "auto" does
-      # the same thing but at task-execution time, which throws under AGP 8 —
-      # the variant version properties are locked after configuration — so we
-      # resolve the number here, before gradle runs.)
-      # Production is deliberately not adjusted: it is never rebuilt without
-      # a commit, so a duplicate versionCode there means something is wrong
-      # and the publish should fail loudly.
-      - name: Resolve final patch number
-        id: version
-        run: |
-          BUILD_NUMBER="${{ steps.config.outputs.build_number }}"
-          MAJOR="${{ steps.config.outputs.major }}"
-          MINOR="${{ steps.config.outputs.minor }}"
-          # An explicit patch override (manual dispatch) is used exactly as
-          # given — no Play adjustment.
-          if [ "${{ steps.config.outputs.flavor }}" = "Alpha" ] && [ "${{ steps.config.outputs.patch_overridden }}" != "true" ]; then
-            SA="$HOME/keystore/play-service-account.json"
-            b64() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
-            EMAIL=$(jq -r .client_email "$SA")
-            NOW=$(date +%s)
-            HDR=$(printf '{"alg":"RS256","typ":"JWT"}' | b64)
-            CLM=$(printf '{"iss":"%s","scope":"https://www.googleapis.com/auth/androidpublisher","aud":"https://oauth2.googleapis.com/token","iat":%d,"exp":%d}' "$EMAIL" "$NOW" $((NOW+3600)) | b64)
-            jq -r .private_key "$SA" > "$RUNNER_TEMP/sa.key"
-            SIG=$(printf '%s.%s' "$HDR" "$CLM" | openssl dgst -sha256 -sign "$RUNNER_TEMP/sa.key" -binary | b64)
-            rm "$RUNNER_TEMP/sa.key"
-            TOKEN=$(curl -sf -X POST https://oauth2.googleapis.com/token \
-              -d "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=$HDR.$CLM.$SIG" | jq -r .access_token)
-            if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-              echo "::error::Could not get a Play API token to check for versionCode collisions."
-              exit 1
-            fi
-            BASE="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/org.sil.bloom.reader.alpha"
-            EDIT=$(curl -sf -X POST -H "Authorization: Bearer $TOKEN" "$BASE/edits" | jq -r .id)
-            if [ -z "$EDIT" ] || [ "$EDIT" = "null" ]; then
-              echo "::error::Could not open a Play edit to check for versionCode collisions."
-              exit 1
-            fi
-            # Delete the edit even if the list call fails (this shell runs
-            # with -e, so without the trap a failure would skip the cleanup
-            # and orphan the edit).
-            trap 'curl -s -X DELETE -H "Authorization: Bearer $TOKEN" "$BASE/edits/$EDIT" >/dev/null 2>&1 || true' EXIT
-            MAX_CODE=$(curl -sf -H "Authorization: Bearer $TOKEN" "$BASE/edits/$EDIT/apks" | jq '[.apks[]?.versionCode] | max // 0')
-            curl -s -X DELETE -H "Authorization: Bearer $TOKEN" "$BASE/edits/$EDIT" >/dev/null || true
-            trap - EXIT
-            DERIVED_CODE=$(( MAJOR * 100000 + MINOR * 1000 + BUILD_NUMBER ))
-            echo "Highest versionCode on Play: $MAX_CODE; derived: $DERIVED_CODE"
-            if [ "$DERIVED_CODE" -le "$MAX_CODE" ]; then
-              BUILD_NUMBER=$(( MAX_CODE - MAJOR * 100000 - MINOR * 1000 + 1 ))
-              if [ "$BUILD_NUMBER" -lt 1 ] || [ "$BUILD_NUMBER" -gt 999 ]; then
-                echo "::error::Bumped patch $BUILD_NUMBER is out of range; Play's highest versionCode $MAX_CODE is outside the current $MAJOR.$MINOR version block."
-                exit 1
-              fi
-              echo "Derived versionCode collides; bumping patch to $BUILD_NUMBER"
-            fi
-          fi
-          echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "version=$MAJOR.$MINOR.$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "Final version: $MAJOR.$MINOR.$BUILD_NUMBER"
-
       - name: Copy bloom-player assets
         run: ./gradlew copyBloomPlayerAssets
 
       - name: Build and publish to internal track
         run: >
           ./gradlew ${{ steps.config.outputs.tasks }}
-          "-Pbuild.number=${{ steps.version.outputs.build_number }}"
+          "-Pbuild.number=${{ steps.config.outputs.build_number }}"
           "-PplayDryRun=${{ steps.config.outputs.dry_run }}"
+
+      # Alpha uses gradle-play-publisher's resolutionStrategy AUTO (see
+      # playConfigs in app/build.gradle), so a rebuild with no new commits
+      # publishes a higher version than the git-derived one. Read the final
+      # values from the build output; for production (strategy FAIL) they
+      # always equal the derived ones.
+      - name: Read published version
+        id: published
+        run: |
+          META="app/build/outputs/apk/${{ steps.config.outputs.flavor_lc }}/release/output-metadata.json"
+          VERSION_NAME=$(jq -r '.elements[0].versionName' "$META")
+          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "Published versionName $VERSION_NAME (versionCode $(jq -r '.elements[0].versionCode' "$META"))"
 
       # bloomlibrary.org serves the production APK for direct download and
       # reads the version file to know the latest version. Only reached if
@@ -283,7 +229,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.BLOOMLIBRARY_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          printf '%s' "${{ steps.version.outputs.version }}" > bloomReaderVersionNumber.txt
+          printf '%s' "${{ steps.published.outputs.version_name }}" > bloomReaderVersionNumber.txt
           aws s3 cp app/build/outputs/apk/production/release/app-production-release.apk \
             s3://bloomlibrary.org/bloomReader/apks/release/latest/BloomReader.apk
           aws s3 cp bloomReaderVersionNumber.txt \
@@ -294,7 +240,7 @@ jobs:
       - name: Tag the released commit
         if: steps.config.outputs.flavor == 'Production' && steps.config.outputs.dry_run == 'false' && github.ref == 'refs/heads/release'
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
+          TAG="v${{ steps.published.outputs.version_name }}"
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
             if [ "$(git rev-parse "refs/tags/$TAG^{commit}")" = "$(git rev-parse HEAD)" ]; then
               echo "Tag $TAG already exists on this commit (re-run); nothing to do."
@@ -313,7 +259,7 @@ jobs:
       - name: Upload APK artifact
         uses: actions/upload-artifact@v7
         with:
-          name: bloomreader-${{ steps.config.outputs.flavor }}-${{ steps.version.outputs.build_number }}
+          name: bloomreader-${{ steps.published.outputs.version_name }}
           # The build task assembles every flavor; only keep the one published.
           path: app/build/outputs/apk/${{ steps.config.outputs.flavor_lc }}/release/*.apk
           if-no-files-found: warn

--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -27,8 +27,11 @@
 # Versioning: the patch number (3.4.NNN) is the number of commits since
 # versionMajor/versionMinor last changed in app/build.gradle, so it resets to 0
 # automatically when the version is bumped, and master (alpha) and release
-# (production) count independently. NOTE: build.gradle computes versionCode =
-# major*100000 + minor*1000 + patch, so patch must stay below 1000.
+# (production) count independently. Alpha additionally floors its number at
+# (Play's highest uploaded versionCode + 1), so rebuilds with no new commit
+# (e.g. dispatched after a bloom-player update) still publish. NOTE:
+# build.gradle computes versionCode = major*100000 + minor*1000 + patch, so
+# patch must stay below 1000.
 
 name: Publish to Play Console
 
@@ -43,7 +46,7 @@ on:
         options: [Alpha, Production]
         default: Alpha
       patch:
-        description: "Override the patch number (default: commits since the last version bump, plus the +77 legacy alpha offset)"
+        description: "Override the patch number (default: commits since the last version bump; alpha additionally bumps past Play's highest versionCode)"
         type: string
         required: false
         default: ""
@@ -109,6 +112,7 @@ jobs:
               exit 1
             fi
             BUILD_NUMBER="$PATCH_INPUT"
+            echo "patch_overridden=true" >> "$GITHUB_OUTPUT"
           else
             BUMP_COMMIT=$(git log -1 --format=%H -G'^def version(Major|Minor)' -- app/build.gradle)
             if [ -z "$BUMP_COMMIT" ]; then
@@ -118,13 +122,6 @@ jobs:
               exit 1
             fi
             BUILD_NUMBER=$(git rev-list --count "$BUMP_COMMIT..HEAD")
-            # Continuity with the old TeamCity build counter (alpha was at
-            # 3.4.103 when this workflow took over). Keyed to the 3.4 bump
-            # commit, so it expires by itself: the next version bump becomes
-            # the new BUMP_COMMIT and this no longer applies.
-            if [ "$BUMP_COMMIT" = "06dc6358a9a2ea410d5ce9bf6b39474177461618" ] && [ "$FLAVOR" = "Alpha" ]; then
-              BUILD_NUMBER=$(( BUILD_NUMBER + 77 ))
-            fi
           fi
           if [ "$BUILD_NUMBER" -gt 999 ]; then
             echo "::error::patch $BUILD_NUMBER would overflow into the minor-version digits of versionCode"
@@ -151,10 +148,11 @@ jobs:
           MINOR=$(sed -n 's/^def versionMinor = \([0-9]*\).*/\1/p' app/build.gradle)
           echo "flavor=$FLAVOR" >> "$GITHUB_OUTPUT"
           echo "flavor_lc=${FLAVOR,,}" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
           echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "version=$MAJOR.$MINOR.$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
           echo "tasks=$TASKS" >> "$GITHUB_OUTPUT"
-          echo "Publishing flavor $FLAVOR version $MAJOR.$MINOR.$BUILD_NUMBER (tasks: $TASKS)"
+          echo "Derived version $MAJOR.$MINOR.$BUILD_NUMBER for flavor $FLAVOR (tasks: $TASKS)"
 
       - uses: actions/setup-java@v5
         with:
@@ -200,26 +198,69 @@ jobs:
           serviceAccountJsonFile=$HOME/keystore/play-service-account.json
           EOF
 
+      # Alpha is sometimes rebuilt with no new commit (e.g. when a
+      # bloom-player update dispatches this workflow), which would reuse the
+      # same derived patch number and be rejected by Play as a duplicate
+      # versionCode. Ask Play for the highest versionCode already uploaded to
+      # the alpha app and use max(derived, highest + 1).
+      # (gradle-play-publisher 2.8's built-in resolutionStrategy "auto" does
+      # the same thing but at task-execution time, which throws under AGP 8 —
+      # the variant version properties are locked after configuration — so we
+      # resolve the number here, before gradle runs.)
+      # Production is deliberately not adjusted: it is never rebuilt without
+      # a commit, so a duplicate versionCode there means something is wrong
+      # and the publish should fail loudly.
+      - name: Resolve final patch number
+        id: version
+        run: |
+          BUILD_NUMBER="${{ steps.config.outputs.build_number }}"
+          MAJOR="${{ steps.config.outputs.major }}"
+          MINOR="${{ steps.config.outputs.minor }}"
+          # An explicit patch override (manual dispatch) is used exactly as
+          # given — no Play adjustment.
+          if [ "${{ steps.config.outputs.flavor }}" = "Alpha" ] && [ "${{ steps.config.outputs.patch_overridden }}" != "true" ]; then
+            SA="$HOME/keystore/play-service-account.json"
+            b64() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+            EMAIL=$(jq -r .client_email "$SA")
+            NOW=$(date +%s)
+            HDR=$(printf '{"alg":"RS256","typ":"JWT"}' | b64)
+            CLM=$(printf '{"iss":"%s","scope":"https://www.googleapis.com/auth/androidpublisher","aud":"https://oauth2.googleapis.com/token","iat":%d,"exp":%d}' "$EMAIL" "$NOW" $((NOW+3600)) | b64)
+            jq -r .private_key "$SA" > "$RUNNER_TEMP/sa.key"
+            SIG=$(printf '%s.%s' "$HDR" "$CLM" | openssl dgst -sha256 -sign "$RUNNER_TEMP/sa.key" -binary | b64)
+            rm "$RUNNER_TEMP/sa.key"
+            TOKEN=$(curl -sf -X POST https://oauth2.googleapis.com/token \
+              -d "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=$HDR.$CLM.$SIG" | jq -r .access_token)
+            if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+              echo "::error::Could not get a Play API token to check for versionCode collisions."
+              exit 1
+            fi
+            BASE="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/org.sil.bloom.reader.alpha"
+            EDIT=$(curl -sf -X POST -H "Authorization: Bearer $TOKEN" "$BASE/edits" | jq -r .id)
+            MAX_CODE=$(curl -sf -H "Authorization: Bearer $TOKEN" "$BASE/edits/$EDIT/apks" | jq '[.apks[]?.versionCode] | max // 0')
+            curl -sf -X DELETE -H "Authorization: Bearer $TOKEN" "$BASE/edits/$EDIT" >/dev/null || true
+            DERIVED_CODE=$(( MAJOR * 100000 + MINOR * 1000 + BUILD_NUMBER ))
+            echo "Highest versionCode on Play: $MAX_CODE; derived: $DERIVED_CODE"
+            if [ "$DERIVED_CODE" -le "$MAX_CODE" ]; then
+              BUILD_NUMBER=$(( MAX_CODE - MAJOR * 100000 - MINOR * 1000 + 1 ))
+              if [ "$BUILD_NUMBER" -lt 1 ] || [ "$BUILD_NUMBER" -gt 999 ]; then
+                echo "::error::Bumped patch $BUILD_NUMBER is out of range; Play's highest versionCode $MAX_CODE is outside the current $MAJOR.$MINOR version block."
+                exit 1
+              fi
+              echo "Derived versionCode collides; bumping patch to $BUILD_NUMBER"
+            fi
+          fi
+          echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "version=$MAJOR.$MINOR.$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Final version: $MAJOR.$MINOR.$BUILD_NUMBER"
+
       - name: Copy bloom-player assets
         run: ./gradlew copyBloomPlayerAssets
 
       - name: Build and publish to internal track
         run: >
           ./gradlew ${{ steps.config.outputs.tasks }}
-          "-Pbuild.number=${{ steps.config.outputs.build_number }}"
+          "-Pbuild.number=${{ steps.version.outputs.build_number }}"
           "-PplayDryRun=${{ steps.config.outputs.dry_run }}"
-
-      # Alpha uses gradle-play-publisher's resolutionStrategy "auto" (see
-      # app/build.gradle), so a rebuild with no new commits publishes a
-      # higher version than the git-derived one. Read the final values from
-      # the build output.
-      - name: Read published version
-        id: published
-        run: |
-          META="app/build/outputs/apk/${{ steps.config.outputs.flavor_lc }}/release/output-metadata.json"
-          VERSION_NAME=$(jq -r '.elements[0].versionName' "$META")
-          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
-          echo "Published versionName $VERSION_NAME (versionCode $(jq -r '.elements[0].versionCode' "$META"))"
 
       # bloomlibrary.org serves the production APK for direct download and
       # reads the version file to know the latest version. Only reached if
@@ -233,7 +274,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.BLOOMLIBRARY_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          printf '%s' "${{ steps.config.outputs.version }}" > bloomReaderVersionNumber.txt
+          printf '%s' "${{ steps.version.outputs.version }}" > bloomReaderVersionNumber.txt
           aws s3 cp app/build/outputs/apk/production/release/app-production-release.apk \
             s3://bloomlibrary.org/bloomReader/apks/release/latest/BloomReader.apk
           aws s3 cp bloomReaderVersionNumber.txt \
@@ -244,7 +285,7 @@ jobs:
       - name: Tag the released commit
         if: steps.config.outputs.flavor == 'Production' && steps.config.outputs.dry_run == 'false' && github.ref == 'refs/heads/release'
         run: |
-          TAG="v${{ steps.config.outputs.version }}"
+          TAG="v${{ steps.version.outputs.version }}"
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
             if [ "$(git rev-parse "refs/tags/$TAG^{commit}")" = "$(git rev-parse HEAD)" ]; then
               echo "Tag $TAG already exists on this commit (re-run); nothing to do."
@@ -263,7 +304,7 @@ jobs:
       - name: Upload APK artifact
         uses: actions/upload-artifact@v7
         with:
-          name: bloomreader-${{ steps.published.outputs.version_name }}
+          name: bloomreader-${{ steps.config.outputs.flavor }}-${{ steps.version.outputs.build_number }}
           # The build task assembles every flavor; only keep the one published.
           path: app/build/outputs/apk/${{ steps.config.outputs.flavor_lc }}/release/*.apk
           if-no-files-found: warn

--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -236,8 +236,17 @@ jobs:
             fi
             BASE="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/org.sil.bloom.reader.alpha"
             EDIT=$(curl -sf -X POST -H "Authorization: Bearer $TOKEN" "$BASE/edits" | jq -r .id)
+            if [ -z "$EDIT" ] || [ "$EDIT" = "null" ]; then
+              echo "::error::Could not open a Play edit to check for versionCode collisions."
+              exit 1
+            fi
+            # Delete the edit even if the list call fails (this shell runs
+            # with -e, so without the trap a failure would skip the cleanup
+            # and orphan the edit).
+            trap 'curl -s -X DELETE -H "Authorization: Bearer $TOKEN" "$BASE/edits/$EDIT" >/dev/null 2>&1 || true' EXIT
             MAX_CODE=$(curl -sf -H "Authorization: Bearer $TOKEN" "$BASE/edits/$EDIT/apks" | jq '[.apks[]?.versionCode] | max // 0')
-            curl -sf -X DELETE -H "Authorization: Bearer $TOKEN" "$BASE/edits/$EDIT" >/dev/null || true
+            curl -s -X DELETE -H "Authorization: Bearer $TOKEN" "$BASE/edits/$EDIT" >/dev/null || true
+            trap - EXIT
             DERIVED_CODE=$(( MAJOR * 100000 + MINOR * 1000 + BUILD_NUMBER ))
             echo "Highest versionCode on Play: $MAX_CODE; derived: $DERIVED_CODE"
             if [ "$DERIVED_CODE" -le "$MAX_CODE" ]; then

--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -209,6 +209,18 @@ jobs:
           "-Pbuild.number=${{ steps.config.outputs.build_number }}"
           "-PplayDryRun=${{ steps.config.outputs.dry_run }}"
 
+      # Alpha uses gradle-play-publisher's resolutionStrategy "auto" (see
+      # app/build.gradle), so a rebuild with no new commits publishes a
+      # higher version than the git-derived one. Read the final values from
+      # the build output.
+      - name: Read published version
+        id: published
+        run: |
+          META="app/build/outputs/apk/${{ steps.config.outputs.flavor_lc }}/release/output-metadata.json"
+          VERSION_NAME=$(jq -r '.elements[0].versionName' "$META")
+          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "Published versionName $VERSION_NAME (versionCode $(jq -r '.elements[0].versionCode' "$META"))"
+
       # bloomlibrary.org serves the production APK for direct download and
       # reads the version file to know the latest version. Only reached if
       # the publish above succeeded. Requiring the release ref (redundant
@@ -251,7 +263,7 @@ jobs:
       - name: Upload APK artifact
         uses: actions/upload-artifact@v7
         with:
-          name: bloomreader-${{ steps.config.outputs.flavor }}-${{ steps.config.outputs.build_number }}
+          name: bloomreader-${{ steps.published.outputs.version_name }}
           # The build task assembles every flavor; only keep the one published.
           path: app/build/outputs/apk/${{ steps.config.outputs.flavor_lc }}/release/*.apk
           if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ commit that changed those two lines. Consequences:
 - Until the next version bump, alpha patch numbers include a hardcoded +77
   offset for continuity with the old TeamCity build counter. It is keyed to
   the 3.4 bump commit and expires on its own (see the workflow).
+- Alpha is sometimes rebuilt with no new commit (e.g. when a bloom-player
+  update dispatches the workflow), which would reuse the same versionCode.
+  The alpha flavor therefore uses gradle-play-publisher's
+  `resolutionStrategy = "auto"` (see `playConfigs` in app/build.gradle): each
+  publish uses max(derived number, highest on Play + 1). Production keeps the
+  strict default and fails on a duplicate, since it is never rebuilt without
+  a commit.
 
 #### The legacy 1.4 APK
 

--- a/README.md
+++ b/README.md
@@ -196,13 +196,12 @@ commit that changed those two lines. Consequences:
   below 1000; the workflow fails if it would overflow.
 - Alpha is sometimes rebuilt with no new commit (e.g. when a bloom-player
   update dispatches the workflow), which would reuse the same versionCode.
-  Before running gradle, the workflow therefore asks the Play API for the
-  alpha app's highest uploaded versionCode and uses max(derived number,
-  highest + 1). Production is deliberately not adjusted: it is never rebuilt
-  without a commit, so a duplicate versionCode there means something is wrong
-  and the publish fails loudly. (gradle-play-publisher 2.8's built-in
-  `resolutionStrategy = "auto"` cannot be used for this: it overrides the
-  version at task-execution time, which AGP 8 forbids.)
+  The alpha flavor therefore uses gradle-play-publisher's
+  `resolutionStrategy = AUTO` (see `playConfigs` in app/build.gradle): each
+  publish uses max(derived number, highest on Play + 1), and the version name
+  is kept in sync with the final code. Production deliberately keeps the
+  strict default (FAIL): it is never rebuilt without a commit, so a duplicate
+  versionCode there means something is wrong and the publish fails loudly.
 
 #### The legacy 1.4 APK
 

--- a/README.md
+++ b/README.md
@@ -151,14 +151,18 @@ where `storeFile` is an absolute path to `keystore_bloom_reader.keystore`. This 
 
 To publish to the Play Store, we use a gradle plugin: `https://github.com/Triple-T/gradle-play-publisher`. To use the plugin locally, you must add `serviceAccountJsonFile=` to the `.properties` file described above. Set the value as an absolute path to the `Google Play Android Developer-cf6d1afc73be.json` file which you must obtain from a member of the team.
 
-Gradle tasks which can be called with the plugin include:
+Gradle tasks which can be called with the plugin include (run
+`./gradlew tasks --group publishing` for the full list):
 
-- publish{Alpha/Beta/Production}Release
+- publish{Alpha/Production}ReleaseApps
   - pushes both the apk and listing metadata to the Play Store
-- publish{Alpha/Beta/Production}ReleaseApk
+- publish{Alpha/Production}ReleaseApk
   - pushes only the apk to the Play Store
-- publish{Alpha/Beta/Production}ReleaseListing
+- publish{Alpha/Production}ReleaseListing
   - pushes only the listing metadata to the Play Store
+- promote{Alpha/Production}ReleaseArtifact
+  - promotes a release between tracks (see fromTrack/promoteTrack in
+    app/build.gradle)
 
 ### CI/CD (GitHub Actions)
 

--- a/README.md
+++ b/README.md
@@ -194,16 +194,15 @@ commit that changed those two lines. Consequences:
 - `master` (alpha) and `release` (production) have independent patch numbers.
 - versionCode = major\*100000 + minor\*1000 + patch, so the patch must stay
   below 1000; the workflow fails if it would overflow.
-- Until the next version bump, alpha patch numbers include a hardcoded +77
-  offset for continuity with the old TeamCity build counter. It is keyed to
-  the 3.4 bump commit and expires on its own (see the workflow).
 - Alpha is sometimes rebuilt with no new commit (e.g. when a bloom-player
   update dispatches the workflow), which would reuse the same versionCode.
-  The alpha flavor therefore uses gradle-play-publisher's
-  `resolutionStrategy = "auto"` (see `playConfigs` in app/build.gradle): each
-  publish uses max(derived number, highest on Play + 1). Production keeps the
-  strict default and fails on a duplicate, since it is never rebuilt without
-  a commit.
+  Before running gradle, the workflow therefore asks the Play API for the
+  alpha app's highest uploaded versionCode and uses max(derived number,
+  highest + 1). Production is deliberately not adjusted: it is never rebuilt
+  without a commit, so a duplicate versionCode there means something is wrong
+  and the publish fails loudly. (gradle-play-publisher 2.8's built-in
+  `resolutionStrategy = "auto"` cannot be used for this: it overrides the
+  version at task-execution time, which AGP 8 forbids.)
 
 #### The legacy 1.4 APK
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,6 +120,27 @@ android {
     }
 
     playConfigs {
+        alpha {
+            // Alpha is sometimes rebuilt with no new commit (e.g. when a
+            // bloom-player update dispatches the CI workflow), which would
+            // reuse the same git-derived versionCode and be rejected as a
+            // duplicate. "auto" asks Play for the highest published code and
+            // uses max(local, highest + 1), so such rebuilds step past the
+            // collision while normal builds keep their derived number.
+            // Production deliberately keeps the default ("fail"): it is never
+            // rebuilt without a commit, so a duplicate there means something
+            // is wrong.
+            // Gated on credentials because "auto" wires a Play API call into
+            // the alpha release build, which would break local builds that
+            // have no credentials (and no ability to publish anyway).
+            resolutionStrategy = keystoreProperties ? "auto" : "fail"
+            // Runs after resolution: keep the visible version name in sync
+            // with the (possibly bumped) final version code.
+            outputProcessor { output ->
+                int code = output.versionCodeOverride > 0 ? output.versionCodeOverride : output.versionCode
+                output.versionNameOverride = "${code.intdiv(100000)}.${(code % 100000).intdiv(1000)}.${code % 1000}-alpha"
+            }
+        }
         production {
             // Each production release must continue to offer the legacy 1.4
             // build (versionCode 104001) so devices below our current

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -120,27 +120,13 @@ android {
     }
 
     playConfigs {
-        alpha {
-            // Alpha is sometimes rebuilt with no new commit (e.g. when a
-            // bloom-player update dispatches the CI workflow), which would
-            // reuse the same git-derived versionCode and be rejected as a
-            // duplicate. "auto" asks Play for the highest published code and
-            // uses max(local, highest + 1), so such rebuilds step past the
-            // collision while normal builds keep their derived number.
-            // Production deliberately keeps the default ("fail"): it is never
-            // rebuilt without a commit, so a duplicate there means something
-            // is wrong.
-            // Gated on credentials because "auto" wires a Play API call into
-            // the alpha release build, which would break local builds that
-            // have no credentials (and no ability to publish anyway).
-            resolutionStrategy = keystoreProperties ? "auto" : "fail"
-            // Runs after resolution: keep the visible version name in sync
-            // with the (possibly bumped) final version code.
-            outputProcessor { output ->
-                int code = output.versionCodeOverride > 0 ? output.versionCodeOverride : output.versionCode
-                output.versionNameOverride = "${code.intdiv(100000)}.${(code % 100000).intdiv(1000)}.${code % 1000}-alpha"
-            }
-        }
+        // NOTE: do not be tempted by gradle-play-publisher 2.8's
+        // resolutionStrategy = "auto" for handling versionCode collisions: it
+        // sets versionCodeOverride at task-execution time, and under AGP 8
+        // the variant version properties are locked after configuration, so
+        // every publish would fail with "The value for this property cannot
+        // be changed any further." The CI workflow instead resolves the
+        // final patch number against the Play API before gradle runs.
         production {
             // Each production release must continue to offer the legacy 1.4
             // build (versionCode 104001) so devices below our current

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,9 @@
 plugins {
     id 'com.android.application'
-    id 'com.github.triplet.play' version '2.8.0'
+    id 'com.github.triplet.play' version '3.13.0'
 }
+
+import com.github.triplet.gradle.androidpublisher.ResolutionStrategy
 
 // This is the master definition of what version of Bloom Reader we are building
 // NOTE: CI derives the patch number by counting commits since the last commit
@@ -101,9 +103,10 @@ android {
     play {
         if (keystoreProperties) {
             serviceAccountCredentials = file(keystoreProperties['serviceAccountJsonFile'])
-        } else {
-            serviceAccountCredentials = file("dummy.json")
         }
+        // (When no credentials file is configured, publish tasks simply can't
+        // run; building is unaffected. CI could alternatively use the
+        // ANDROID_PUBLISHER_CREDENTIALS environment variable.)
 
         // We default to always uploading to internal initially. This makes the new apk
         // available much sooner for testing. Then we can promote it to whichever channel we
@@ -120,20 +123,26 @@ android {
     }
 
     playConfigs {
-        // NOTE: do not be tempted by gradle-play-publisher 2.8's
-        // resolutionStrategy = "auto" for handling versionCode collisions: it
-        // sets versionCodeOverride at task-execution time, and under AGP 8
-        // the variant version properties are locked after configuration, so
-        // every publish would fail with "The value for this property cannot
-        // be changed any further." The CI workflow instead resolves the
-        // final patch number against the Play API before gradle runs.
+        alpha {
+            // Alpha is sometimes rebuilt with no new commit (e.g. when a
+            // bloom-player update dispatches the CI workflow), which would
+            // reuse the same derived versionCode and be rejected by Play as
+            // a duplicate. AUTO asks Play for the highest uploaded code and
+            // publishes max(local, highest + 1); the version name is kept in
+            // sync by the androidComponents block below. Gated on
+            // credentials so local builds (which can't publish anyway) don't
+            // acquire a Play API dependency. Production deliberately keeps
+            // the default (FAIL): it is never rebuilt without a commit, so a
+            // duplicate there means something is wrong.
+            resolutionStrategy = keystoreProperties ? ResolutionStrategy.AUTO : ResolutionStrategy.FAIL
+        }
         production {
             // Each production release must continue to offer the legacy 1.4
             // build (versionCode 104001) so devices below our current
             // minSdkVersion keep getting a working app. Retaining it here
             // means every publish includes it automatically instead of
             // relying on a manual step in the Play Console.
-            retain.artifacts = [104001L]
+            retain.artifacts.set([104001L])
         }
     }
 
@@ -149,14 +158,30 @@ android {
     }
 }
 
+// Keep the alpha version name in sync with the version code that
+// gradle-play-publisher's AUTO resolution may bump (see playConfigs above).
+// This is the plugin's documented pattern: with AUTO, output.versionCode
+// becomes a provider of the final resolved code.
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        if (variant.flavorName == "alpha") {
+            variant.outputs.each { output ->
+                output.versionName.set(output.versionCode.map { code ->
+                    "${code.intdiv(100000)}.${(code % 100000).intdiv(1000)}.${code % 1000}-alpha"
+                })
+            }
+        }
+    }
+}
+
 // Fail any production publish that is not going to retain the legacy 1.4 APK
 // (see the playConfigs block above) rather than let a release silently drop
 // it -- e.g. if a gradle-play-publisher upgrade changes how retain is
 // configured or applied. This reads the merged config off the publish task
 // itself (the value the task will actually use). The hasProperty filter
-// skips the plugin's plain "...Wrapper" companion tasks, which carry no
-// config; the isEmpty check keeps this loud if a plugin upgrade renames
-// everything and the filter no longer matches any task at all.
+// skips the plugin's plain lifecycle/companion tasks, which carry no config;
+// the isEmpty check keeps this loud if a plugin upgrade renames everything
+// and the filter no longer matches any task at all.
 project.afterEvaluate {
     def guarded = tasks.findAll {
         it.name.startsWith('publishProduction') && it.hasProperty('extension')
@@ -166,8 +191,8 @@ project.afterEvaluate {
     }
     guarded.each { task ->
         task.doFirst {
-            def retained = task.extension.retain.artifacts
-            if (retained == null || !retained.contains(104001L)) {
+            def retained = task.extension.retain.artifacts.getOrElse([])
+            if (!retained.contains(104001L)) {
                 throw new GradleException("${task.name} is not configured to retain the legacy 1.4 APK (versionCode 104001). See playConfigs in app/build.gradle.")
             }
         }


### PR DESCRIPTION
## Problem

Alpha is sometimes rebuilt with no new commit — most commonly when a bloom-player update dispatches the publish workflow. The git-derived patch number (commits since the last version bump) then repeats, so the publish fails with a duplicate-versionCode rejection from Play. This just happened in practice.

## Fix (final shape)

**Upgrade gradle-play-publisher 2.8.0 → 3.13.0** and let the plugin handle collisions natively: the alpha flavor sets `resolutionStrategy = AUTO` (scoped via `playConfigs`), which publishes **max(derived versionCode, highest on Play + 1)**. The version name is kept in sync with the resolved code via the plugin's documented `androidComponents.onVariants` pattern, and the workflow reads the actually-published version from `output-metadata.json` for the artifact name, tag, and bloomlibrary.org version file.

- **Production deliberately keeps the strict default (FAIL)**: it is never rebuilt without a commit, so a duplicate versionCode there means something is wrong and should fail loudly.
- AUTO is **gated on Play credentials being present**, so local builds don't acquire a Play API dependency.
- The AUTO floor makes the +77 legacy TeamCity offset redundant (removed) and neutralizes the "editing the version lines resets the counter" hazard for alpha.
- Migration notes: `publishAlphaRelease` → `publishAlphaReleaseApps`; `serviceAccountCredentials` is now optional (dummy.json fallback removed); retain and the retain-guard use the Property API.

## How it got here (for reviewers reading the commit history)

1. `13505ef` tried GPP **2.8's** `resolutionStrategy = "auto"` — review caught, and a local probe confirmed, that 2.8's execution-time overrides throw under AGP 8 ("The value for this property cannot be changed any further"); every CI publish would have failed.
2. `c5400d8`/`c16ad01` replaced it with a hand-rolled Play API query (JWT + `edits/apks.list`) in the workflow — correct but ~60 lines of bash.
3. `9ebaccb` upgraded the plugin to 3.13.0, whose AUTO works properly on AGP 8, and deleted the bash. Net simpler than where we started.

## Verification

- Locally: gradle configures on 3.13; the alpha versionName wiring verified end-to-end on a real build (`3.4.42-alpha` / `304042` in output-metadata.json); the retain guard reads `[104001]` off the real publish task; the credentials gate yields FAIL locally; task graphs for both flavors resolve; full unit-test suite green.
- End-to-end proof still requires a real run: after merging, re-dispatch the workflow with no new commit (the exact scenario that failed) and confirm it publishes highest+1 with a matching name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomReader/330)
<!-- Reviewable:end -->
